### PR TITLE
Alternate line boundary hotkeys

### DIFF
--- a/src/event/keydown.ts
+++ b/src/event/keydown.ts
@@ -13,10 +13,13 @@ import { processE } from "./keydown_key/e.ts";
  * @param event event listener {@link KeyboardEvent}
  */
 export function keydown(event: KeyboardEvent) {
+  // Requires duplicates for capitalisable keys as per https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#value
   const keyHandlerMap = new Map<string, (event: KeyboardEvent) => void>([
+    ["a", processA],
     ["A", processA],
     ["ArrowDown", processArrowDown],
     ["ArrowUp", processArrowUp],
+    ["e", processE],
     ["E", processE],
     ["End", processEnd],
     ["Enter", processEnter],

--- a/src/event/keydown.ts
+++ b/src/event/keydown.ts
@@ -4,6 +4,8 @@ import { processArrowUp } from "./keydown_key/arrow_up.ts";
 import { processArrowDown } from "./keydown_key/arrow_down.ts";
 import { processEnd } from "./keydown_key/end.ts";
 import { processHome } from "./keydown_key/home.ts";
+import { processA } from "./keydown_key/a.ts";
+import { processE } from "./keydown_key/e.ts";
 
 /**
  * Event listener function for handling key down events in the terminal.
@@ -11,24 +13,19 @@ import { processHome } from "./keydown_key/home.ts";
  * @param event event listener {@link KeyboardEvent}
  */
 export function keydown(event: KeyboardEvent) {
-  switch (event.key) {
-    case "Enter":
-      processEnter(event);
-      break;
-    case "Tab":
-      processTab(event);
-      break;
-    case "ArrowUp":
-      processArrowUp(event);
-      break;
-    case "ArrowDown":
-      processArrowDown(event);
-      break;
-    case "End":
-      processEnd(event);
-      break;
-    case "Home":
-      processHome(event);
-      break;
+  const keyHandlerMap = new Map<string, (event: KeyboardEvent) => void>([
+    ["A", processA],
+    ["ArrowDown", processArrowDown],
+    ["ArrowUp", processArrowUp],
+    ["E", processE],
+    ["End", processEnd],
+    ["Enter", processEnter],
+    ["Home", processHome],
+    ["Tab", processTab],
+  ]);
+
+  const handler = keyHandlerMap.get(event.key);
+  if (handler) {
+    handler(event);
   }
 }

--- a/src/event/keydown_key/a.ts
+++ b/src/event/keydown_key/a.ts
@@ -1,0 +1,10 @@
+/**
+ * Processes the 'A' key event. Moves the cursor to the start of the user input
+ * if 'Ctrl' is also pressed.
+ *
+ * @param event event listener {@link KeyboardEvent}
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function processA(event: KeyboardEvent) {
+  // TODO: call processHome
+}

--- a/src/event/keydown_key/a.ts
+++ b/src/event/keydown_key/a.ts
@@ -1,10 +1,13 @@
+import { processHome } from "./home.ts";
+
 /**
  * Processes the 'A' key event. Moves the cursor to the start of the user input
  * if 'Ctrl' is also pressed.
  *
  * @param event event listener {@link KeyboardEvent}
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function processA(event: KeyboardEvent) {
-  // TODO: call processHome
+  if (event.ctrlKey) {
+    processHome(event);
+  }
 }

--- a/src/event/keydown_key/e.ts
+++ b/src/event/keydown_key/e.ts
@@ -1,0 +1,10 @@
+/**
+ * Processes the 'E' key event. Moves the cursor to the end of the user input
+ * if 'Ctrl' is also pressed.
+ *
+ * @param event event listener {@link KeyboardEvent}
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function processE(event: KeyboardEvent) {
+  // TODO: call processEnd
+}

--- a/src/event/keydown_key/e.ts
+++ b/src/event/keydown_key/e.ts
@@ -1,10 +1,13 @@
+import { processEnd } from "./end.ts";
+
 /**
  * Processes the 'E' key event. Moves the cursor to the end of the user input
  * if 'Ctrl' is also pressed.
  *
  * @param event event listener {@link KeyboardEvent}
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function processE(event: KeyboardEvent) {
-  // TODO: call processEnd
+  if (event.ctrlKey) {
+    processEnd(event);
+  }
 }

--- a/test/e2e/spec/jump_to_line_boundaries.spec.ts
+++ b/test/e2e/spec/jump_to_line_boundaries.spec.ts
@@ -11,15 +11,29 @@ const defaultInput = "foo, bar ?<baz>gaz</baz> asd> // testing";
 [
   {
     button: "Home",
+    withCtrl: false,
+    expectedText: "the beginning of the user input",
+    expectedPosition: defaultReadOnly.length,
+  },
+  {
+    button: "a",
+    withCtrl: true,
     expectedText: "the beginning of the user input",
     expectedPosition: defaultReadOnly.length,
   },
   {
     button: "End",
+    withCtrl: false,
     expectedText: "the end of the user input",
     expectedPosition: defaultReadOnly.length + defaultInput.length,
   },
-].forEach(({ button, expectedText, expectedPosition }) => {
+  {
+    button: "e",
+    withCtrl: true,
+    expectedText: "the end of the user input",
+    expectedPosition: defaultReadOnly.length + defaultInput.length,
+  },
+].forEach(({ button, withCtrl, expectedText, expectedPosition }) => {
   test.describe(`Pressing '${button}'`, () => {
     test.beforeEach(async ({ page }) => {
       await page.locator(terminalSelector).pressSequentially(defaultInput);
@@ -45,7 +59,15 @@ const defaultInput = "foo, bar ?<baz>gaz</baz> asd> // testing";
         await setCaretAtCharIndex(page, terminalSelector, startIndex);
 
         // Act
+        if (withCtrl) {
+          await page.keyboard.down("Control");
+        }
+
         await page.locator(terminalSelector).press(button);
+
+        if (withCtrl) {
+          await page.keyboard.up("Control");
+        }
 
         // Assert
         const caretPos = await page.evaluate(() => {

--- a/test/integration/src/event/keydown.test.ts
+++ b/test/integration/src/event/keydown.test.ts
@@ -44,9 +44,11 @@ describe("Keydown Event", () => {
     ];
 
     test.each([
+      { key: "a", expected: processA },
       { key: "A", expected: processA },
       { key: "ArrowDown", expected: processArrowDown },
       { key: "ArrowUp", expected: processArrowUp },
+      { key: "e", expected: processE },
       { key: "E", expected: processE },
       { key: "End", expected: processEnd },
       { key: "Enter", expected: processEnter },

--- a/test/integration/src/event/keydown.test.ts
+++ b/test/integration/src/event/keydown.test.ts
@@ -6,42 +6,52 @@ import * as arrowUpModule from "../../../../src/event/keydown_key/arrow_up";
 import * as arrowDownModule from "../../../../src/event/keydown_key/arrow_down";
 import * as endModule from "../../../../src/event/keydown_key/end";
 import * as homeModule from "../../../../src/event/keydown_key/home";
+import * as aModule from "../../../../src/event/keydown_key/a";
+import * as eModule from "../../../../src/event/keydown_key/e";
 
 describe("Keydown Event", () => {
   describe("keydown", () => {
     // Spy
-    const processEnter = vi.spyOn(enterModule, "processEnter");
-    const processTab = vi.spyOn(tabModule, "processTab");
-    const processArrowUp = vi.spyOn(arrowUpModule, "processArrowUp");
+    const processA = vi.spyOn(aModule, "processA");
     const processArrowDown = vi.spyOn(arrowDownModule, "processArrowDown");
+    const processArrowUp = vi.spyOn(arrowUpModule, "processArrowUp");
+    const processE = vi.spyOn(eModule, "processE");
     const processEnd = vi.spyOn(endModule, "processEnd");
+    const processEnter = vi.spyOn(enterModule, "processEnter");
     const processHome = vi.spyOn(homeModule, "processHome");
+    const processTab = vi.spyOn(tabModule, "processTab");
 
     // Mock
-    vi.mock("../../../../src/event/keydown_key/enter");
-    vi.mock("../../../../src/event/keydown_key/tab");
-    vi.mock("../../../../src/event/keydown_key/arrow_up");
+    vi.mock("../../../../src/event/keydown_key/a");
     vi.mock("../../../../src/event/keydown_key/arrow_down");
+    vi.mock("../../../../src/event/keydown_key/arrow_up");
+    vi.mock("../../../../src/event/keydown_key/e");
     vi.mock("../../../../src/event/keydown_key/end");
+    vi.mock("../../../../src/event/keydown_key/enter");
     vi.mock("../../../../src/event/keydown_key/home");
+    vi.mock("../../../../src/event/keydown_key/tab");
 
     // Other
     const functions = [
-      processEnter,
-      processTab,
-      processArrowUp,
+      processA,
       processArrowDown,
+      processArrowUp,
+      processE,
       processEnd,
+      processEnter,
       processHome,
+      processTab,
     ];
 
     test.each([
-      { key: "Enter", expected: processEnter },
-      { key: "Tab", expected: processTab },
-      { key: "ArrowUp", expected: processArrowUp },
+      { key: "A", expected: processA },
       { key: "ArrowDown", expected: processArrowDown },
+      { key: "ArrowUp", expected: processArrowUp },
+      { key: "E", expected: processE },
       { key: "End", expected: processEnd },
+      { key: "Enter", expected: processEnter },
       { key: "Home", expected: processHome },
+      { key: "Tab", expected: processTab },
     ])("calls correct function when '$key' is pressed", ({ key, expected }) => {
       // Arrange
       const event = new KeyboardEvent("keydown", { key });

--- a/test/integration/src/event/keydown_key/a.test.ts
+++ b/test/integration/src/event/keydown_key/a.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect, vi } from "vitest";
+import { processA } from "../../../../../src/event/keydown_key/a";
+import * as homeModule from "../../../../../src/event/keydown_key/home";
+
+describe("A", () => {
+  describe("processA", () => {
+    // Spy
+    const processHome = vi.spyOn(homeModule, "processHome");
+
+    // Mock
+    vi.mock("../../../../../src/event/keydown_key/home");
+
+    test("with 'Ctrl' moves the cursor to the start of the user input", () => {
+      // Arrange
+      const event = new KeyboardEvent("keydown", { ctrlKey: true });
+
+      // Act
+      processA(event);
+
+      // Assert
+      expect(processHome).toHaveBeenCalledOnce();
+    });
+
+    test("without 'Ctrl' does nothing", () => {
+      // Arrange
+      const event = new KeyboardEvent("keydown");
+
+      // Act
+      processA(event);
+
+      // Assert
+      expect(processHome).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/integration/src/event/keydown_key/e.test.ts
+++ b/test/integration/src/event/keydown_key/e.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect, vi } from "vitest";
+import * as endModule from "../../../../../src/event/keydown_key/end";
+import { processE } from "../../../../../src/event/keydown_key/e";
+
+describe("E", () => {
+  describe("processE", () => {
+    // Spy
+    const processEnd = vi.spyOn(endModule, "processEnd");
+
+    // Mock
+    vi.mock("../../../../../src/event/keydown_key/end");
+
+    test("with 'Ctrl' moves the cursor to the end of the user input", () => {
+      // Arrange
+      const event = new KeyboardEvent("keydown", { ctrlKey: true });
+
+      // Act
+      processE(event);
+
+      // Assert
+      expect(processEnd).toHaveBeenCalledOnce();
+    });
+
+    test("without 'Ctrl' does nothing", () => {
+      // Arrange
+      const event = new KeyboardEvent("keydown");
+
+      // Act
+      processE(event);
+
+      // Assert
+      expect(processEnd).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# Features
- 'Ctrl+A' & 'Ctrl+E' moves caret to beginning/ending of user input

# Other
- Refactor Keydown