### PR TITLE
Cleanup code

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,7 +16,53 @@ export default defineConfig([
     rules: {
       "@stylistic/semi": ["error", "always"],
       "@stylistic/quotes": ["error", "double"],
-      "eqeqeq": ["error", "smart"]
+      eqeqeq: ["error", "smart"],
+      "@typescript-eslint/naming-convention": [
+        "error",
+
+        // Destructured Variables (ignore formatting as per https://typescript-eslint.io/rules/naming-convention/#ignore-destructured-names)
+        {
+          selector: "variable",
+          modifiers: ["destructured"],
+          format: null,
+        },
+
+        // Variables (not Global Const)
+        {
+          selector: "variable",
+          format: ["camelCase"],
+        },
+
+        // Global Const Variables
+        {
+          selector: "variable",
+          modifiers: ["const", "global"],
+          format: ["UPPER_CASE"],
+        },
+
+        // Classes
+        {
+          selector: "class",
+          format: ["PascalCase"],
+        },
+
+        // Functions
+        {
+          selector: "function",
+          format: ["camelCase"],
+          leadingUnderscore: "allow",
+        },
+
+        // Enums
+        {
+          selector: "enum",
+          format: ["PascalCase"],
+        },
+        {
+          selector: "enumMember",
+          format: ["UPPER_CASE"],
+        },
+      ],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "prepare": "husky",
+    "eslint:check": "eslint",
+    "eslint:fix": "eslint . --fix",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "vitest run --project Unit",
     "test:integration": "vitest run --project Integration",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ import { defineConfig, devices } from "@playwright/test";
  * - https://playwright.dev/docs/api/class-testconfig
  */
 
-const serverUrl = "http://localhost:5173";
+const SERVER_URL = "http://localhost:5173";
 
 // noinspection JSUnusedGlobalSymbols
 export default defineConfig({
@@ -25,7 +25,7 @@ export default defineConfig({
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    baseURL: serverUrl,
+    baseURL: SERVER_URL,
     headless: true,
     trace: "on-first-retry",
   },
@@ -90,7 +90,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: "npm run dev",
-    url: serverUrl,
+    url: SERVER_URL,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/src/command/scripts/cat.ts
+++ b/src/command/scripts/cat.ts
@@ -5,29 +5,6 @@ import FileSystemUtil from "../../util/file_system_util.ts";
 import { escape } from "lodash-es";
 import CommandUtil from "../../util/command_util.ts";
 
-/**
- * Replaces Markdown URLs with an Anchor Element.
- * <p>
- * Escapes any other text.
- *
- * @param text the text to modify
- *
- * @returns text with Anchor elements and escaped text
- */
-function insertAnchorElements(text: string): string {
-  return text.replace(
-    /\[([^\]]+)]\(([^)]+)\)|([^[]+)/g,
-    (_match, text, url, outside) => {
-      // Text outside of []()
-      if (outside !== undefined) {
-        return escape(outside);
-      } else {
-        return `<a href='${url}' target='_blank'>${text}</a>`;
-      }
-    },
-  );
-}
-
 const CAT: CommandScript = {
   async run(args: string[]): Promise<void> {
     const parsedOptions = CommandUtil.parseArgs("cat", args, {});
@@ -63,3 +40,26 @@ const CAT: CommandScript = {
 
 // noinspection JSUnusedGlobalSymbols
 export default CAT;
+
+/**
+ * Replaces Markdown URLs with an Anchor Element.
+ * <p>
+ * Escapes any other text.
+ *
+ * @param text the text to modify
+ *
+ * @returns text with Anchor elements and escaped text
+ */
+function insertAnchorElements(text: string): string {
+  return text.replace(
+    /\[([^\]]+)]\(([^)]+)\)|([^[]+)/g,
+    (_match, text, url, outside) => {
+      // Text outside of []()
+      if (outside !== undefined) {
+        return escape(outside);
+      } else {
+        return `<a href='${url}' target='_blank'>${text}</a>`;
+      }
+    },
+  );
+}

--- a/src/command/scripts/cat.ts
+++ b/src/command/scripts/cat.ts
@@ -28,7 +28,7 @@ function insertAnchorElements(text: string): string {
   );
 }
 
-const cat: CommandScript = {
+const CAT: CommandScript = {
   async run(args: string[]): Promise<void> {
     const parsedOptions = CommandUtil.parseArgs("cat", args, {});
 
@@ -62,4 +62,4 @@ const cat: CommandScript = {
 };
 
 // noinspection JSUnusedGlobalSymbols
-export default cat;
+export default CAT;

--- a/src/command/scripts/cd.ts
+++ b/src/command/scripts/cd.ts
@@ -109,10 +109,9 @@ function getPreviousWorkingDirectory(): string | null {
 }
 
 /**
- * Resets the working directories variable. Intended to only be used by Unit Tests
- * to reset state.
+ * Resets the working directories variable.
  *
- * @internal
+ * @internal **intended to be solely used by Tests**
  */
 export function _resetWorkingDirectories() {
   workingDirectories = [];

--- a/src/command/scripts/cd.ts
+++ b/src/command/scripts/cd.ts
@@ -74,7 +74,7 @@ function changeDirectory(path: string) {
 //  1. cd into <DIR>
 //  2. cd -
 //  3. Should CD successfully and not output an error!
-const cd: CommandScript = {
+const CD: CommandScript = {
   async run(args: string[]): Promise<void> {
     const parsedOptions = CommandUtil.parseArgs("cd", args, {});
 
@@ -116,4 +116,4 @@ const cd: CommandScript = {
 };
 
 // noinspection JSUnusedGlobalSymbols
-export default cd;
+export default CD;

--- a/src/command/scripts/cd.ts
+++ b/src/command/scripts/cd.ts
@@ -5,71 +5,6 @@ import CommandUtil from "../../util/command_util.ts";
 
 let workingDirectories: string[] = [];
 
-/**
- * Resets the working directories variable. Intended to only be used by Unit Tests
- * to reset state.
- *
- * @internal
- */
-export function _resetWorkingDirectories() {
-  workingDirectories = [];
-}
-
-/**
- * @returns the Previous Working Directory or null if it does not exist.
- */
-function getPreviousWorkingDirectory(): string | null {
-  if (workingDirectories.length !== 2) {
-    return null;
-  }
-
-  return workingDirectories[0];
-}
-
-/**
- * Adds a working directory to a cache.
- * <p>
- * This is used to determine the Previous Working Directory, see {@link getPreviousWorkingDirectory}.
- *
- * @param directory the working directory to add.
- */
-function addWorkingDirectory(directory: string) {
-  workingDirectories.push(directory);
-
-  if (workingDirectories.length > 2) {
-    workingDirectories.shift();
-  }
-}
-
-/**
- * Changes the directory & prompt to the provided path if it is valid.
- * <p>
- * A series of error messages are created on the frontend if the path is not valid.
- *
- * @param path the path to change to.
- */
-function changeDirectory(path: string) {
-  const resolvedPathParts = FileSystemUtil.resolvePathParts(path);
-
-  if (resolvedPathParts === null) {
-    TerminalUtil.appendOutput(`\nbash: cd: ${path}: No such file or directory`);
-    return;
-  }
-
-  if (FileSystemUtil.doesFileExist(resolvedPathParts)) {
-    TerminalUtil.appendOutput(`\nbash: cd: ${path}: Not a directory`);
-    return;
-  } else if (!FileSystemUtil.doesDirectoryExist(resolvedPathParts)) {
-    TerminalUtil.appendOutput(`\nbash: cd: ${path}: No such file or directory`);
-    return;
-  }
-
-  const formattedPath = FileSystemUtil.formatPath(resolvedPathParts);
-
-  FileSystemUtil.setCurrentWorkingDirectory(formattedPath);
-  addWorkingDirectory(formattedPath);
-}
-
 // TODO: Add test for:
 //  1. cd into <DIR>
 //  2. cd -
@@ -117,3 +52,68 @@ const CD: CommandScript = {
 
 // noinspection JSUnusedGlobalSymbols
 export default CD;
+
+/**
+ * Changes the directory & prompt to the provided path if it is valid.
+ * <p>
+ * A series of error messages are created on the frontend if the path is not valid.
+ *
+ * @param path the path to change to.
+ */
+function changeDirectory(path: string) {
+  const resolvedPathParts = FileSystemUtil.resolvePathParts(path);
+
+  if (resolvedPathParts === null) {
+    TerminalUtil.appendOutput(`\nbash: cd: ${path}: No such file or directory`);
+    return;
+  }
+
+  if (FileSystemUtil.doesFileExist(resolvedPathParts)) {
+    TerminalUtil.appendOutput(`\nbash: cd: ${path}: Not a directory`);
+    return;
+  } else if (!FileSystemUtil.doesDirectoryExist(resolvedPathParts)) {
+    TerminalUtil.appendOutput(`\nbash: cd: ${path}: No such file or directory`);
+    return;
+  }
+
+  const formattedPath = FileSystemUtil.formatPath(resolvedPathParts);
+
+  FileSystemUtil.setCurrentWorkingDirectory(formattedPath);
+  addWorkingDirectory(formattedPath);
+}
+
+/**
+ * Adds a working directory to a cache.
+ * <p>
+ * This is used to determine the Previous Working Directory, see {@link getPreviousWorkingDirectory}.
+ *
+ * @param directory the working directory to add.
+ */
+function addWorkingDirectory(directory: string) {
+  workingDirectories.push(directory);
+
+  if (workingDirectories.length > 2) {
+    workingDirectories.shift();
+  }
+}
+
+/**
+ * @returns the Previous Working Directory or null if it does not exist.
+ */
+function getPreviousWorkingDirectory(): string | null {
+  if (workingDirectories.length !== 2) {
+    return null;
+  }
+
+  return workingDirectories[0];
+}
+
+/**
+ * Resets the working directories variable. Intended to only be used by Unit Tests
+ * to reset state.
+ *
+ * @internal
+ */
+export function _resetWorkingDirectories() {
+  workingDirectories = [];
+}

--- a/src/command/scripts/clear.ts
+++ b/src/command/scripts/clear.ts
@@ -1,7 +1,7 @@
 import { CommandScript } from "../command_script.ts";
 import TerminalUtil from "../../util/terminal_util.ts";
 
-const clear: CommandScript = {
+const CLEAR: CommandScript = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async run(_args: string[]): Promise<void> {
     TerminalUtil.setOutput("");
@@ -9,4 +9,4 @@ const clear: CommandScript = {
 };
 
 // noinspection JSUnusedGlobalSymbols
-export default clear;
+export default CLEAR;

--- a/src/command/scripts/echo.ts
+++ b/src/command/scripts/echo.ts
@@ -5,7 +5,7 @@ import TerminalUtil from "../../util/terminal_util.ts";
 import getopts, { ParsedOptions } from "getopts";
 
 // TODO: Change echo so that this command works (try in terminal then site): echo -a sadoas das''a as '"'
-const echo: CommandScript = {
+const ECHO: CommandScript = {
   async run(args: string[]): Promise<void> {
     // Don't rely on CommandUtil.parseArgs as we want to silently ignore any error flags
     const parsedOptions: ParsedOptions = getopts(args);
@@ -16,4 +16,4 @@ const echo: CommandScript = {
 };
 
 // noinspection JSUnusedGlobalSymbols
-export default echo;
+export default ECHO;

--- a/src/command/scripts/echo.ts
+++ b/src/command/scripts/echo.ts
@@ -5,6 +5,7 @@ import TerminalUtil from "../../util/terminal_util.ts";
 import getopts, { ParsedOptions } from "getopts";
 
 // TODO: Change echo so that this command works (try in terminal then site): echo -a sadoas das''a as '"'
+// TODO: change so that 'echo ' does not leave a hanging newline. Run the same command multiple times to see the problem.
 const ECHO: CommandScript = {
   async run(args: string[]): Promise<void> {
     // Don't rely on CommandUtil.parseArgs as we want to silently ignore any error flags

--- a/src/command/scripts/ls.ts
+++ b/src/command/scripts/ls.ts
@@ -75,20 +75,10 @@ interface Flags {
   blockSize: number | null;
 }
 
-// TODO: Make this extend the FileTreeNode. See if we can remove any code doing this, e.g. sortEntryNodes -> FileSystemUtil.sortNodes
-interface EntryNode {
-  name: string;
-  path: string;
-  fullPath: string;
-  isDirectory: boolean;
+interface EntryNode extends FileTreeNode {
   children: EntryNode[];
-  lastModifiedTime: Date;
-  size: number;
-  permissions: number[];
-  owner: string;
-  group: string;
+  fullPath: string;
   hardLinks: number;
-  blocks: number;
 }
 
 interface PathResults {
@@ -247,7 +237,7 @@ function formatUnknownPaths(unknownPaths: string[]): string {
  * @returns the formatted file entries.
  */
 function formatFileEntries(fileEntries: EntryNode[], flags: Flags): string {
-  sortEntryNodes(fileEntries);
+  fileEntries = sortEntryNodes(fileEntries);
 
   const outputs: string[] = [];
   for (const fileEntry of fileEntries) {
@@ -281,7 +271,7 @@ function formatDirectoryEntries(
 ) {
   const outputs: string[] = [];
 
-  sortEntryNodes(directoryEntries);
+  directoryEntries = sortEntryNodes(directoryEntries);
 
   for (const directoryEntry of directoryEntries) {
     const directoryEntryChildren = getSortedDirectoryEntryChildren(
@@ -335,9 +325,7 @@ function getSortedDirectoryEntryChildren(
   directoryEntry: EntryNode,
   flags: Flags,
 ): EntryNode[] {
-  let children = directoryEntry.children;
-
-  sortEntryNodes(children);
+  let children = sortEntryNodes(directoryEntry.children);
 
   // Add after sorting to ensure these appear first
   if (flags.a) {
@@ -371,13 +359,8 @@ function getSortedDirectoryEntryChildren(
  * @param nodes the nodes to sort inline.
  * @see stripLeadingDots
  */
-function sortEntryNodes(nodes: EntryNode[]) {
-  nodes.sort((a, b) => {
-    const aString = FileSystemUtil.stripDots(a.fullPath);
-    const bString = FileSystemUtil.stripDots(b.fullPath);
-
-    return aString.localeCompare(bString);
-  });
+function sortEntryNodes(nodes: EntryNode[]): EntryNode[] {
+  return FileSystemUtil.sortNodes(nodes) as EntryNode[];
 }
 
 /**

--- a/src/command/scripts/ls.ts
+++ b/src/command/scripts/ls.ts
@@ -489,7 +489,7 @@ function formatDateTime(datetime: Date): string {
 // TODO: 'ls -1s' works but 'ls -s1' does not work. This is an issue with the getopts
 //  library. Planning on investigating a more maintained alternative so this is
 //  a low priority issue for now.
-const ls: CommandScript = {
+const LS: CommandScript = {
   async run(args: string[]): Promise<void> {
     const parsedOptions = CommandUtil.parseArgs("ls", args, {
       boolean: ["a", "1", "s", "h", "l"],
@@ -544,4 +544,4 @@ const ls: CommandScript = {
 };
 
 // noinspection JSUnusedGlobalSymbols
-export default ls;
+export default LS;

--- a/src/command/scripts/ls.ts
+++ b/src/command/scripts/ls.ts
@@ -6,6 +6,76 @@ import ColourUtil from "../../util/colour_util.ts";
 import { clone } from "lodash-es";
 import CommandUtil from "../../util/command_util.ts";
 
+// TODO: 'ls -1s' works but 'ls -s1' does not work. This is an issue with the getopts
+//  library. Planning on investigating a more maintained alternative so this is
+//  a low priority issue for now.
+const LS: CommandScript = {
+  async run(args: string[]): Promise<void> {
+    const parsedOptions = CommandUtil.parseArgs("ls", args, {
+      boolean: ["a", "1", "s", "h", "l"],
+      string: ["block-size"],
+      alias: {
+        all: ["a"],
+        size: ["s"],
+        "human-readable": ["h"],
+      },
+    });
+
+    if (parsedOptions === null) {
+      return;
+    }
+
+    let blockSize: number | null = null;
+    const blockSizeRaw: string = parsedOptions["block-size"];
+    if (blockSizeRaw) {
+      blockSize = parseInt(blockSizeRaw);
+
+      if (blockSizeRaw.includes(".") || isNaN(blockSize) || blockSize < 1) {
+        TerminalUtil.appendOutput(
+          `ls: invalid --block-size argument '${parsedOptions["block-size"]}'`,
+        );
+        return;
+      }
+    }
+
+    const paths: string[] =
+      parsedOptions._.length > 0
+        ? parsedOptions._
+        : [
+            FileSystemUtil.formatPath(
+              FileSystemUtil.getCurrentWorkingDirectory(),
+            ),
+          ];
+
+    const pathResults = processPaths(paths);
+    const output = formatPathResults(pathResults, {
+      a: parsedOptions.a,
+      "1": parsedOptions["1"],
+      s: parsedOptions.s,
+      h: parsedOptions.h,
+      l: parsedOptions.l,
+      blockSize: blockSize,
+    });
+
+    if (output !== "") {
+      TerminalUtil.appendRawOutput(`\n${output}`);
+    }
+  },
+};
+
+// noinspection JSUnusedGlobalSymbols
+export default LS;
+
+interface Flags {
+  a: boolean;
+  1: boolean;
+  s: boolean;
+  h: boolean;
+  l: boolean;
+  blockSize: number | null;
+}
+
+// TODO: Make this extend the FileTreeNode. See if we can remove any code doing this, e.g. sortEntryNodes -> FileSystemUtil.sortNodes
 interface EntryNode {
   name: string;
   path: string;
@@ -25,15 +95,6 @@ interface PathResults {
   unknownPaths: string[];
   fileEntries: EntryNode[];
   directoryEntries: EntryNode[];
-}
-
-interface FormatFlags {
-  a: boolean;
-  1: boolean;
-  s: boolean;
-  h: boolean;
-  l: boolean;
-  blockSize: number | null;
 }
 
 /**
@@ -123,10 +184,7 @@ function createEntryNode(fileTreeNode: FileTreeNode): EntryNode {
  * @param flags all format related flags.
  * @returns structured human-readable text.
  */
-function formatPathResults(
-  pathResults: PathResults,
-  flags: FormatFlags,
-): string {
+function formatPathResults(pathResults: PathResults, flags: Flags): string {
   let output = "";
 
   const unknownPathOutput = formatUnknownPaths(pathResults.unknownPaths);
@@ -188,10 +246,7 @@ function formatUnknownPaths(unknownPaths: string[]): string {
  * @param flags flags for formatting.
  * @returns the formatted file entries.
  */
-function formatFileEntries(
-  fileEntries: EntryNode[],
-  flags: FormatFlags,
-): string {
+function formatFileEntries(fileEntries: EntryNode[], flags: Flags): string {
   sortEntryNodes(fileEntries);
 
   const outputs: string[] = [];
@@ -222,7 +277,7 @@ function formatFileEntries(
 function formatDirectoryEntries(
   directoryEntries: EntryNode[],
   isPreviousOutput: boolean,
-  flags: FormatFlags,
+  flags: Flags,
 ) {
   const outputs: string[] = [];
 
@@ -278,7 +333,7 @@ function formatDirectoryEntries(
  */
 function getSortedDirectoryEntryChildren(
   directoryEntry: EntryNode,
-  flags: FormatFlags,
+  flags: Flags,
 ): EntryNode[] {
   let children = directoryEntry.children;
 
@@ -310,6 +365,22 @@ function getSortedDirectoryEntryChildren(
 }
 
 /**
+ * Sorts EntryNodes alphabetically by their `fullPath`, ignoring any starting
+ * '.' characters.
+ *
+ * @param nodes the nodes to sort inline.
+ * @see stripLeadingDots
+ */
+function sortEntryNodes(nodes: EntryNode[]) {
+  nodes.sort((a, b) => {
+    const aString = FileSystemUtil.stripDots(a.fullPath);
+    const bString = FileSystemUtil.stripDots(b.fullPath);
+
+    return aString.localeCompare(bString);
+  });
+}
+
+/**
  * Sorts and Formats Directory Entry Children.
  * <p>
  * Children will be coloured based on {@link ColourUtil.getFileSystemEntry}.
@@ -320,7 +391,7 @@ function getSortedDirectoryEntryChildren(
  */
 function formatDirectoryEntryChildren(
   children: EntryNode[],
-  flags: FormatFlags,
+  flags: Flags,
 ): string[] {
   const formattedChildren: string[] = [];
 
@@ -340,11 +411,7 @@ function formatDirectoryEntryChildren(
  * @param flags the formatting flags.
  * @param useShortName true to use the entry name, false to use the full path.
  */
-function formatEntry(
-  entry: EntryNode,
-  flags: FormatFlags,
-  useShortName: boolean,
-) {
+function formatEntry(entry: EntryNode, flags: Flags, useShortName: boolean) {
   const fileSystemEntry = ColourUtil.getFileSystemEntry(
     {
       name: entry.name,
@@ -383,19 +450,20 @@ function formatEntry(
 }
 
 /**
- * Sorts EntryNodes alphabetically by their `fullPath`, ignoring any starting
- * '.' characters.
- *
- * @param nodes the nodes to sort inline.
- * @see stripLeadingDots
+ * Formats the provided `dateTime` into a string.
+ * @param datetime the datetime to convert.
+ * @returns a datetime string, e.g. `17 Aug 00:33`.
  */
-function sortEntryNodes(nodes: EntryNode[]) {
-  nodes.sort((a, b) => {
-    const aString = FileSystemUtil.stripDots(a.fullPath);
-    const bString = FileSystemUtil.stripDots(b.fullPath);
-
-    return aString.localeCompare(bString);
-  });
+function formatDateTime(datetime: Date): string {
+  return datetime
+    .toLocaleString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    })
+    .replace(",", "");
 }
 
 /**
@@ -406,7 +474,7 @@ function sortEntryNodes(nodes: EntryNode[]) {
  * @param entry the entry to get the size of.
  * @param flags the formatting flags.
  */
-function getSize(entry: EntryNode, flags: FormatFlags): string {
+function getSize(entry: EntryNode, flags: Flags): string {
   if (flags.h && !flags.blockSize) {
     /*
     Functionally this is wrong. FileSystemUtil.getHumanReadableSize does NOT return the same values we'd expect in a
@@ -430,7 +498,7 @@ function getSize(entry: EntryNode, flags: FormatFlags): string {
  * @param entry the entry to get the size of.
  * @param flags the formatting flags.
  */
-function getBlockSize(entry: EntryNode, flags: FormatFlags): string {
+function getBlockSize(entry: EntryNode, flags: Flags): string {
   if (flags.h && !flags.blockSize) {
     return FileSystemUtil.getHumanReadableSize(entry.blocks * 512);
   }
@@ -447,7 +515,7 @@ function getBlockSize(entry: EntryNode, flags: FormatFlags): string {
  * @param entries the entries to get the total size of.
  * @param flags the formatting flags.
  */
-function getTotalBlockSize(entries: EntryNode[], flags: FormatFlags): string {
+function getTotalBlockSize(entries: EntryNode[], flags: Flags): string {
   let output: string;
 
   if (flags.h && !flags.blockSize) {
@@ -468,80 +536,3 @@ function getTotalBlockSize(entries: EntryNode[], flags: FormatFlags): string {
 
   return output;
 }
-
-/**
- * Formats the provided `dateTime` into a string.
- * @param datetime the datetime to convert.
- * @returns a datetime string, e.g. `17 Aug 00:33`.
- */
-function formatDateTime(datetime: Date): string {
-  return datetime
-    .toLocaleString("en-US", {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    })
-    .replace(",", "");
-}
-
-// TODO: 'ls -1s' works but 'ls -s1' does not work. This is an issue with the getopts
-//  library. Planning on investigating a more maintained alternative so this is
-//  a low priority issue for now.
-const LS: CommandScript = {
-  async run(args: string[]): Promise<void> {
-    const parsedOptions = CommandUtil.parseArgs("ls", args, {
-      boolean: ["a", "1", "s", "h", "l"],
-      string: ["block-size"],
-      alias: {
-        all: ["a"],
-        size: ["s"],
-        "human-readable": ["h"],
-      },
-    });
-
-    if (parsedOptions === null) {
-      return;
-    }
-
-    let blockSize: number | null = null;
-    const blockSizeRaw: string = parsedOptions["block-size"];
-    if (blockSizeRaw) {
-      blockSize = parseInt(blockSizeRaw);
-
-      if (blockSizeRaw.includes(".") || isNaN(blockSize) || blockSize < 1) {
-        TerminalUtil.appendOutput(
-          `ls: invalid --block-size argument '${parsedOptions["block-size"]}'`,
-        );
-        return;
-      }
-    }
-
-    const paths: string[] =
-      parsedOptions._.length > 0
-        ? parsedOptions._
-        : [
-            FileSystemUtil.formatPath(
-              FileSystemUtil.getCurrentWorkingDirectory(),
-            ),
-          ];
-
-    const pathResults = processPaths(paths);
-    const output = formatPathResults(pathResults, {
-      a: parsedOptions.a,
-      "1": parsedOptions["1"],
-      s: parsedOptions.s,
-      h: parsedOptions.h,
-      l: parsedOptions.l,
-      blockSize: blockSize,
-    });
-
-    if (output !== "") {
-      TerminalUtil.appendRawOutput(`\n${output}`);
-    }
-  },
-};
-
-// noinspection JSUnusedGlobalSymbols
-export default LS;

--- a/src/command/scripts/pwd.ts
+++ b/src/command/scripts/pwd.ts
@@ -2,7 +2,7 @@ import { CommandScript } from "../command_script.ts";
 import FileSystemUtil from "../../util/file_system_util.ts";
 import TerminalUtil from "../../util/terminal_util.ts";
 
-const pwd: CommandScript = {
+const PWD: CommandScript = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async run(_args: string[]): Promise<void> {
     const currentWorkingDirectory = FileSystemUtil.getCurrentWorkingDirectory();
@@ -14,4 +14,4 @@ const pwd: CommandScript = {
 };
 
 // noinspection JSUnusedGlobalSymbols
-export default pwd;
+export default PWD;

--- a/src/command/scripts/tree.ts
+++ b/src/command/scripts/tree.ts
@@ -5,6 +5,54 @@ import TerminalUtil from "../../util/terminal_util.ts";
 import ColourUtil from "../../util/colour_util.ts";
 import { FileTreeNode } from "virtual:file-tree";
 
+const TREE: CommandScript = {
+  async run(args: string[]): Promise<void> {
+    const parsedOptions = CommandUtil.parseArgs("tree", args, {
+      boolean: ["a", "d", "prune", "f"],
+      string: ["L"],
+    });
+
+    if (parsedOptions === null) {
+      return;
+    }
+
+    const paths: string[] =
+      parsedOptions._.length > 0
+        ? parsedOptions._
+        : [
+            FileSystemUtil.formatPath(
+              FileSystemUtil.getCurrentWorkingDirectory(),
+            ),
+          ];
+
+    let lFlagValue: number = -1;
+    const lFlagValueRaw: string = parsedOptions.L;
+    if (lFlagValueRaw) {
+      lFlagValue = parseInt(lFlagValueRaw);
+
+      if (isNaN(lFlagValue) || lFlagValue < 1) {
+        TerminalUtil.appendOutput(
+          "\ntree: Invalid level, must be greater than 0.",
+        );
+        return;
+      }
+    }
+
+    const output: string = generateOutput(paths, {
+      a: parsedOptions.a,
+      d: parsedOptions.d,
+      prune: parsedOptions.prune,
+      f: parsedOptions.f,
+      L: lFlagValue,
+    });
+
+    TerminalUtil.appendRawOutput(`\n${output}`);
+  },
+};
+
+// noinspection JSUnusedGlobalSymbols
+export default TREE;
+
 interface Flags {
   a: boolean;
   d: boolean;
@@ -234,51 +282,3 @@ function filterNodes(nodes: FileTreeNode[], flags: Flags): FileTreeNode[] {
 
   return nodes;
 }
-
-const TREE: CommandScript = {
-  async run(args: string[]): Promise<void> {
-    const parsedOptions = CommandUtil.parseArgs("tree", args, {
-      boolean: ["a", "d", "prune", "f"],
-      string: ["L"],
-    });
-
-    if (parsedOptions === null) {
-      return;
-    }
-
-    const paths: string[] =
-      parsedOptions._.length > 0
-        ? parsedOptions._
-        : [
-            FileSystemUtil.formatPath(
-              FileSystemUtil.getCurrentWorkingDirectory(),
-            ),
-          ];
-
-    let lFlagValue: number = -1;
-    const lFlagValueRaw: string = parsedOptions.L;
-    if (lFlagValueRaw) {
-      lFlagValue = parseInt(lFlagValueRaw);
-
-      if (isNaN(lFlagValue) || lFlagValue < 1) {
-        TerminalUtil.appendOutput(
-          "\ntree: Invalid level, must be greater than 0.",
-        );
-        return;
-      }
-    }
-
-    const output: string = generateOutput(paths, {
-      a: parsedOptions.a,
-      d: parsedOptions.d,
-      prune: parsedOptions.prune,
-      f: parsedOptions.f,
-      L: lFlagValue,
-    });
-
-    TerminalUtil.appendRawOutput(`\n${output}`);
-  },
-};
-
-// noinspection JSUnusedGlobalSymbols
-export default TREE;

--- a/src/command/scripts/tree.ts
+++ b/src/command/scripts/tree.ts
@@ -235,7 +235,7 @@ function filterNodes(nodes: FileTreeNode[], flags: Flags): FileTreeNode[] {
   return nodes;
 }
 
-const tree: CommandScript = {
+const TREE: CommandScript = {
   async run(args: string[]): Promise<void> {
     const parsedOptions = CommandUtil.parseArgs("tree", args, {
       boolean: ["a", "d", "prune", "f"],
@@ -281,4 +281,4 @@ const tree: CommandScript = {
 };
 
 // noinspection JSUnusedGlobalSymbols
-export default tree;
+export default TREE;

--- a/src/constant/char.ts
+++ b/src/constant/char.ts
@@ -1,1 +1,1 @@
-export const zeroWidthSpace = "\u200B";
+export const ZERO_WIDTH_SPACE = "\u200B";

--- a/src/constant/prompt.ts
+++ b/src/constant/prompt.ts
@@ -1,4 +1,4 @@
-import { zeroWidthSpace } from "./char.ts";
+import { ZERO_WIDTH_SPACE } from "./char.ts";
 
-export const initialPrompt = `Microsoft Windows [Version 10.0.18363.1379]\n(c) 2019 Microsoft Corporation. All rights reserved.\n${zeroWidthSpace}`;
-export const userPrompt = "C:\\home\\nathanwise>";
+export const INITIAL_PROMPT = `Microsoft Windows [Version 10.0.18363.1379]\n(c) 2019 Microsoft Corporation. All rights reserved.\n${ZERO_WIDTH_SPACE}`;
+export const USER_PROMPT = "C:\\home\\nathanwise>";

--- a/src/event/keydown_key/home.ts
+++ b/src/event/keydown_key/home.ts
@@ -1,5 +1,5 @@
 import TerminalUtil from "../../util/terminal_util.ts";
-import { zeroWidthSpace } from "../../constant/char.ts";
+import { ZERO_WIDTH_SPACE } from "../../constant/char.ts";
 
 /**
  * Processes the 'Home' key event. Moves the cursor to the start of the user input.
@@ -9,7 +9,7 @@ import { zeroWidthSpace } from "../../constant/char.ts";
 export async function processHome(event: KeyboardEvent) {
   event.preventDefault();
 
-  if (TerminalUtil.getRawInput().startsWith(zeroWidthSpace)) {
+  if (TerminalUtil.getRawInput().startsWith(ZERO_WIDTH_SPACE)) {
     TerminalUtil.cursorToIndex(1);
   } else {
     TerminalUtil.cursorToIndex(0);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import TerminalUtil from "./util/terminal_util.ts";
 import { paste } from "./event/paste.ts";
 import { keydown } from "./event/keydown.ts";
-import { initialPrompt } from "./constant/prompt.ts";
+import { INITIAL_PROMPT } from "./constant/prompt.ts";
 import FileSystemUtil from "./util/file_system_util.ts";
 import { click } from "./event/click.ts";
 
@@ -9,12 +9,12 @@ import { click } from "./event/click.ts";
 FileSystemUtil.setHomeDirectory("/home/nathanwise");
 FileSystemUtil.setCurrentWorkingDirectory("~");
 
-TerminalUtil.setOutput(initialPrompt);
+TerminalUtil.setOutput(INITIAL_PROMPT);
 TerminalUtil.setInput("");
 
 // Event Listeners
 document.addEventListener("click", click);
 
-const inputElement = TerminalUtil.getInputElement();
-inputElement.addEventListener("paste", paste);
-inputElement.addEventListener("keydown", keydown);
+const INPUT_ELEMENT = TerminalUtil.getInputElement();
+INPUT_ELEMENT.addEventListener("paste", paste);
+INPUT_ELEMENT.addEventListener("keydown", keydown);

--- a/src/plugins/vite_plugin_file_tree.ts
+++ b/src/plugins/vite_plugin_file_tree.ts
@@ -246,7 +246,7 @@ function storeAsOrphan(
  *
  * console.info(fileTree);
  */
-export default function FileTree(
+export default function fileTree(
   rootPath?: string,
   homeDirectory?: string,
 ): Plugin {

--- a/src/util/autocomplete_util.ts
+++ b/src/util/autocomplete_util.ts
@@ -1,5 +1,5 @@
 import TerminalUtil from "./terminal_util.ts";
-import { userPrompt } from "../constant/prompt.ts";
+import { USER_PROMPT } from "../constant/prompt.ts";
 import MetaImportUtil from "./meta_import_util.ts";
 import FileSystemUtil from "./file_system_util.ts";
 import { Suggestion } from "../command/command_script.ts";
@@ -49,7 +49,7 @@ export default class AutocompleteUtil {
 
       // TODO: Make this use TUI (columns) when that's implemented
       TerminalUtil.appendOutput(
-        `${userPrompt}${userInput}\n${joinedSuggestions}`,
+        `${USER_PROMPT}${userInput}\n${joinedSuggestions}`,
         true,
       );
     }

--- a/src/util/command_history_util.ts
+++ b/src/util/command_history_util.ts
@@ -4,15 +4,19 @@ export default class CommandHistoryUtil {
 
   /**
    * Gets the history index which acts as a pointer to the current location in history.
+   *
+   * @internal **intended to be solely used by Tests**
    */
-  public static getHistoryIndex() {
+  public static _getHistoryIndex() {
     return this.historyIndex;
   }
 
   /**
    * Resets the command history to be empty and resets the history index to match.
+   *
+   * @internal **intended to be solely used by Tests**
    */
-  public static resetHistory() {
+  public static _resetHistory() {
     this.history = [];
     this.resetHistoryIndex();
   }

--- a/src/util/file_import_util.ts
+++ b/src/util/file_import_util.ts
@@ -2,7 +2,7 @@
 // .gitkeep should not be included, see 'walk' in 'vite_plugin_file_tree.ts' for in-depth explanation.
 import FileSystemUtil from "./file_system_util.ts";
 
-const files = import.meta.glob<{ default: string }>(
+const FILES = import.meta.glob<{ default: string }>(
   ["./**/*", "!./**/*.gitkeep"],
   {
     exhaustive: true,
@@ -23,11 +23,11 @@ export default class FileImportUtil {
     // '.' is required at the start due to how import meta glob imports work
     filePath = "." + FileSystemUtil.resolvePath(filePath);
 
-    if (!(filePath in files)) {
+    if (!(filePath in FILES)) {
       return null;
     }
 
-    const loader = files[filePath];
+    const loader = FILES[filePath];
     const fileContent = await loader();
     return fileContent.default;
   }

--- a/src/util/meta_import_util.ts
+++ b/src/util/meta_import_util.ts
@@ -1,10 +1,13 @@
 import { CommandScript } from "../command/command_script.ts";
 
 // Does not function correctly as a readonly within MetaImportUtil
-const commandFiles = import.meta.glob<{ default: CommandScript }>("./**/*.ts", {
-  eager: true,
-  base: "/src/command/scripts",
-});
+const COMMAND_FILES = import.meta.glob<{ default: CommandScript }>(
+  "./**/*.ts",
+  {
+    eager: true,
+    base: "/src/command/scripts",
+  },
+);
 
 export default class MetaImportUtil {
   // Vite Glob imports with a base always have './' appended to the start of files found as per https://vite.dev/guide/features.html#base-path
@@ -17,7 +20,7 @@ export default class MetaImportUtil {
    */
   // prettier-ignore
   public static getCommandScripts(): Record<string, { default: CommandScript }> {
-    return commandFiles;
+    return COMMAND_FILES;
   }
 
   /**

--- a/src/util/terminal_util.ts
+++ b/src/util/terminal_util.ts
@@ -1,5 +1,5 @@
 import HtmlUtil from "./html_util.ts";
-import { zeroWidthSpace } from "../constant/char.ts";
+import { ZERO_WIDTH_SPACE } from "../constant/char.ts";
 import { escape, unescape } from "lodash-es";
 import FileSystemUtil from "./file_system_util.ts";
 
@@ -79,7 +79,7 @@ export default class TerminalUtil {
    * @see getRawInput
    */
   public static getInput(): string {
-    return this.getRawInput().replace(zeroWidthSpace, "");
+    return this.getRawInput().replace(ZERO_WIDTH_SPACE, "");
   }
 
   /**
@@ -105,7 +105,7 @@ export default class TerminalUtil {
    */
   public static setInput(text: string) {
     if (text === "") {
-      text = zeroWidthSpace;
+      text = ZERO_WIDTH_SPACE;
     }
 
     this.input.textContent = text;
@@ -175,7 +175,7 @@ export default class TerminalUtil {
    * @param text text to append
    */
   public static appendInput(text: string) {
-    if (this.getRawInput() === zeroWidthSpace) {
+    if (this.getRawInput() === ZERO_WIDTH_SPACE) {
       this.setInput(text);
     } else {
       this.input.textContent += text;

--- a/test/e2e/fixture.ts
+++ b/test/e2e/fixture.ts
@@ -8,6 +8,7 @@ import {
 import { escapeRegExp } from "lodash-es";
 
 // Test
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const test = baseTest.extend({
   page: async ({ page }, use) => {
     await page.goto("/");
@@ -88,6 +89,7 @@ function buildMessage(
     `${errorMessage}\n\nLocator: ${locator}\nExpected: ${expectedMessage}\n${receivedMessage}`;
 }
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const expect = baseExpect.extend({
   /**
    * Checks whether the given element contains the exact provided text.

--- a/test/e2e/helper/constant/generic.ts
+++ b/test/e2e/helper/constant/generic.ts
@@ -10,3 +10,4 @@ export const DEFAULT_USER_PROMPT = "C:\\home\\nathanwise>";
 export const COMMAND_NOT_FOUND = ": command not found";
 export const DEFAULT_CURRENT_WORKING_DIRECTORY = "/home/nathanwise";
 export const DEFAULT_HOME_DIRECTORY = "/home/nathanwise";
+export const COMMAND_RAN_OUTPUT = `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}`;

--- a/test/e2e/helper/constant/generic.ts
+++ b/test/e2e/helper/constant/generic.ts
@@ -1,12 +1,12 @@
 /* Selector */
-export const inputSelector = "#input";
-export const promptSelector = "#prompt";
-export const outputSelector = "#output";
+export const INPUT_SELECTOR = "#input";
+export const PROMPT_SELECTOR = "#prompt";
+export const OUTPUT_SELECTOR = "#output";
 
 /* Read-only */
-export const zeroWidthSpace = "\u200B";
-export const defaultInitialPrompt = `Microsoft Windows [Version 10.0.18363.1379]\n(c) 2019 Microsoft Corporation. All rights reserved.\n${zeroWidthSpace}`;
-export const defaultUserPrompt = "C:\\home\\nathanwise>";
-export const commandNotFound = ": command not found";
-export const defaultCurrentWorkingDirectory = "/home/nathanwise";
-export const defaultHomeDirectory = "/home/nathanwise";
+export const ZERO_WIDTH_SPACE = "\u200B";
+export const DEFAULT_INITIAL_PROMPT = `Microsoft Windows [Version 10.0.18363.1379]\n(c) 2019 Microsoft Corporation. All rights reserved.\n${ZERO_WIDTH_SPACE}`;
+export const DEFAULT_USER_PROMPT = "C:\\home\\nathanwise>";
+export const COMMAND_NOT_FOUND = ": command not found";
+export const DEFAULT_CURRENT_WORKING_DIRECTORY = "/home/nathanwise";
+export const DEFAULT_HOME_DIRECTORY = "/home/nathanwise";

--- a/test/e2e/helper/util/element_util.ts
+++ b/test/e2e/helper/util/element_util.ts
@@ -1,6 +1,6 @@
 import { Page } from "@playwright/test";
 import { expect } from "../../fixture";
-import { outputSelector } from "../constant/generic.ts";
+import { OUTPUT_SELECTOR } from "../constant/generic.ts";
 import {
   BLACK,
   BLUE,
@@ -28,28 +28,28 @@ export async function checkForColouredSpans(
   colouredCounts: ColouredCounts,
 ) {
   await expect(
-    page.locator(outputSelector).locator(getColouredSpanLocator(BLUE)),
+    page.locator(OUTPUT_SELECTOR).locator(getColouredSpanLocator(BLUE)),
   ).toHaveCount(colouredCounts.directory);
 
   await expect(
-    page.locator(outputSelector).locator(getColouredSpanLocator(GREEN)),
+    page.locator(OUTPUT_SELECTOR).locator(getColouredSpanLocator(GREEN)),
   ).toHaveCount(colouredCounts.executables);
 
   await expect(
-    page.locator(outputSelector).locator(getColouredSpanLocator(RED)),
+    page.locator(OUTPUT_SELECTOR).locator(getColouredSpanLocator(RED)),
   ).toHaveCount(colouredCounts.archives);
 
   await expect(
-    page.locator(outputSelector).locator(getColouredSpanLocator(MAGENTA)),
+    page.locator(OUTPUT_SELECTOR).locator(getColouredSpanLocator(MAGENTA)),
   ).toHaveCount(colouredCounts.graphics);
 
   await expect(
-    page.locator(outputSelector).locator(getColouredSpanLocator(CYAN)),
+    page.locator(OUTPUT_SELECTOR).locator(getColouredSpanLocator(CYAN)),
   ).toHaveCount(colouredCounts.audios);
 
   await expect(
     page
-      .locator(outputSelector)
+      .locator(OUTPUT_SELECTOR)
       .locator(`//span[contains(@style, "color: ${BLACK}")]`),
   ).toHaveCount(colouredCounts.rubbish);
 }

--- a/test/e2e/helper/util/terminal_util.ts
+++ b/test/e2e/helper/util/terminal_util.ts
@@ -1,4 +1,12 @@
 import { Page } from "@playwright/test";
+import {
+  DEFAULT_INITIAL_PROMPT,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
+} from "../constant/generic.ts";
+import { expect } from "../../fixture.ts";
 
 /**
  * Places the caret inside a contenteditable element at a given character index.
@@ -34,4 +42,56 @@ export async function setCaretAtCharIndex(
 export function getExpectedPrompt(path: string) {
   const splitPath = path.split("/").filter(Boolean);
   return `C:\\${splitPath.join("\\")}>`;
+}
+
+/**
+ * Runs a command in the Terminal.
+ *
+ * @param page Playwright page instance.
+ * @param command the command and args to run.
+ */
+export async function runCommand(page: Page, command: string) {
+  await page.locator(INPUT_SELECTOR).pressSequentially(command);
+  await page.locator(INPUT_SELECTOR).press("Enter");
+}
+
+/**
+ * Asserts that there is exact text in the Terminal.
+ * <p>
+ * Acts as a helper method for common assert logic. Can be used in one of two ways..
+ * @example
+ * // Generic example for when the output, prompt, and input remain standard
+ * const input = "echo foo bar";
+ * const expected = "\nfoo bar";
+ * await assertExactTextInTerminal(page, `${input}${expected}`);
+ *
+ * // Example for when the prompt changes from the norm
+ * const input = "cd ~/Desktop";
+ * const expectedPrompt = "";
+ * await assertExactTextInTerminal(page, "", undefined, getExpectedPrompt("/home/nathanwise/Desktop"));
+ *
+ * // Example for when the output changes from the norm
+ * const input = "clear";
+ * await assertExactTextInTerminal(page, "", "");
+ *
+ * @param page Playwright page instance.
+ * @param expectedOutput the expected output to append to the default `outputText`.
+ * @param outputText the expected output, leave undefined for the default value if you're planning on relying on `expectedOutput`.
+ * @param promptText the expected prompt, leave undefined to default to {@link DEFAULT_USER_PROMPT}.
+ * @param inputText the expected input, leave undefined to default to an empty string.
+ */
+export async function assertExactTextInTerminal(
+  page: Page,
+  expectedOutput: string,
+  outputText?: string,
+  promptText?: string,
+  inputText?: string,
+) {
+  outputText ??= `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${expectedOutput}`;
+  promptText ??= DEFAULT_USER_PROMPT;
+  inputText ??= "";
+
+  await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(outputText);
+  await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(promptText);
+  await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(inputText);
 }

--- a/test/e2e/helper/util/terminal_util.ts
+++ b/test/e2e/helper/util/terminal_util.ts
@@ -1,6 +1,6 @@
 import { Page } from "@playwright/test";
 import {
-  DEFAULT_INITIAL_PROMPT,
+  COMMAND_RAN_OUTPUT,
   DEFAULT_USER_PROMPT,
   INPUT_SELECTOR,
   OUTPUT_SELECTOR,
@@ -56,6 +56,27 @@ export async function runCommand(page: Page, command: string) {
 }
 
 /**
+ * Asserts that there is `expectedOutput` in the terminal.
+ * <p>
+ * Acts as a shorthand for...
+ * @example
+ * const expectedOutput = "??";
+ * await assertExactTextInTerminal(page, `${COMMAND_RAN_OUTPUT}${expectedOutput}`);
+ *
+ * @param page Playwright page instance
+ * @param expectedOutput the expected command output, ignoring the standard prompt.
+ * @see assertExactTextInTerminal
+ */
+export async function assertOutputInTerminal(
+  page: Page,
+  expectedOutput: string,
+) {
+  const outputText = `${COMMAND_RAN_OUTPUT}${expectedOutput}`;
+
+  await assertExactTextInTerminal(page, outputText);
+}
+
+/**
  * Asserts that there is exact text in the Terminal.
  * <p>
  * Acts as a helper method for common assert logic. Can be used in one of two ways..
@@ -75,19 +96,18 @@ export async function runCommand(page: Page, command: string) {
  * await assertExactTextInTerminal(page, "", "");
  *
  * @param page Playwright page instance.
- * @param expectedOutput the expected output to append to the default `outputText`.
  * @param outputText the expected output, leave undefined for the default value if you're planning on relying on `expectedOutput`.
  * @param promptText the expected prompt, leave undefined to default to {@link DEFAULT_USER_PROMPT}.
  * @param inputText the expected input, leave undefined to default to an empty string.
+ * @see assertOutputInTerminal
  */
 export async function assertExactTextInTerminal(
   page: Page,
-  expectedOutput: string,
   outputText?: string,
   promptText?: string,
   inputText?: string,
 ) {
-  outputText ??= `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${expectedOutput}`;
+  outputText ??= COMMAND_RAN_OUTPUT;
   promptText ??= DEFAULT_USER_PROMPT;
   inputText ??= "";
 

--- a/test/e2e/spec/accessibility.spec.ts
+++ b/test/e2e/spec/accessibility.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "../fixture";
 import AxeBuilder from "@axe-core/playwright";
 import { INPUT_SELECTOR } from "../helper/constant/generic";
+import { runCommand } from "../helper/util/terminal_util.ts";
 
 test.describe("homepage", () => {
   test("should not have any automatically detectable accessibility issues", async ({
@@ -69,8 +70,7 @@ test.describe("focus", () => {
     const input = "cat ~/Projects/this/.external";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     const [newPage] = await Promise.all([
       page.context().waitForEvent("page"),

--- a/test/e2e/spec/accessibility.spec.ts
+++ b/test/e2e/spec/accessibility.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "../fixture";
 import AxeBuilder from "@axe-core/playwright";
-import { inputSelector } from "../helper/constant/generic";
+import { INPUT_SELECTOR } from "../helper/constant/generic";
 
 test.describe("homepage", () => {
   test("should not have any automatically detectable accessibility issues", async ({
@@ -54,7 +54,7 @@ test.describe("focus", () => {
     ];
 
     // Act & Assert
-    const input = page.locator(inputSelector);
+    const input = page.locator(INPUT_SELECTOR);
     for (const corner of corners) {
       await page.mouse.click(corner.x, corner.y);
       await expect(
@@ -69,8 +69,8 @@ test.describe("focus", () => {
     const input = "cat ~/Projects/this/.external";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     const [newPage] = await Promise.all([
       page.context().waitForEvent("page"),

--- a/test/e2e/spec/autocomplete.spec.ts
+++ b/test/e2e/spec/autocomplete.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "../fixture";
 import {
-  defaultInitialPrompt,
-  defaultUserPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  DEFAULT_INITIAL_PROMPT,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../helper/constant/generic";
 
 // Custom command specific E2E tests are under each command spec
@@ -15,17 +15,17 @@ test.describe("Command autocompletion", () => {
     const input = "ech";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Tab");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Tab");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      defaultInitialPrompt,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      DEFAULT_INITIAL_PROMPT,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(`${input}o `);
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(`${input}o `);
   });
 
   test("adds a space when 'echo' has been typed", async ({ page }) => {
@@ -33,31 +33,31 @@ test.describe("Command autocompletion", () => {
     const input = "echo";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Tab");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Tab");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      defaultInitialPrompt,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      DEFAULT_INITIAL_PROMPT,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(`${input} `);
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(`${input} `);
   });
 
   test("does nothing when no text has been inputted", async ({ page }) => {
     // Arrange & Act
-    await page.locator(inputSelector).press("Tab");
+    await page.locator(INPUT_SELECTOR).press("Tab");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      defaultInitialPrompt,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      DEFAULT_INITIAL_PROMPT,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 });
 
@@ -71,17 +71,17 @@ test.describe("File/Directory autocompletion", () => {
       "bin/\tboot/\tdev/\tetc/\thome/\tlib/\tmedia/\tmnt/\topt/\troot/\trun/\tsbin/\tsrv/\ttmp/\tusr/\tvar/";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Tab");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Tab");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${expectedOutput}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expectedOutput}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(input);
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(input);
   });
 
   [
@@ -173,17 +173,17 @@ test.describe("File/Directory autocompletion", () => {
   ].forEach(async ({ type, input, expected }) => {
     test(type, async ({ page }) => {
       // Arrange & Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Tab");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Tab");
 
       // Assert
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        defaultInitialPrompt,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        DEFAULT_INITIAL_PROMPT,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement(
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(
         `${input}${expected}`,
       );
     });

--- a/test/e2e/spec/command/cat.spec.ts
+++ b/test/e2e/spec/command/cat.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "../../fixture";
 import { OUTPUT_SELECTOR } from "../../helper/constant/generic";
 import {
-  assertExactTextInTerminal,
+  assertOutputInTerminal,
   runCommand,
 } from "../../helper/util/terminal_util.ts";
 
@@ -64,7 +64,7 @@ test.describe("Cat", () => {
     await runCommand(page, input);
 
     // Assert
-    await assertExactTextInTerminal(page, input);
+    await assertOutputInTerminal(page, input);
   });
 
   test("should output the contents of a single file, when that file path is given", async ({
@@ -78,7 +78,7 @@ test.describe("Cat", () => {
 
     // Assert
     const expected = `\n${existingFiles[0].content}`;
-    await assertExactTextInTerminal(page, input + expected);
+    await assertOutputInTerminal(page, input + expected);
   });
 
   test("should output the contents of a multiple files, when multiple file paths are given", async ({
@@ -92,7 +92,7 @@ test.describe("Cat", () => {
 
     // Assert
     const expected = `\n${existingFiles[0].content}\n${existingFiles[1].content}`;
-    await assertExactTextInTerminal(page, input + expected);
+    await assertOutputInTerminal(page, input + expected);
   });
 
   test("should output file not found error, when a file path for a non-existent path is given", async ({
@@ -106,7 +106,7 @@ test.describe("Cat", () => {
 
     // Assert
     const expected = `\ncat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
-    await assertExactTextInTerminal(page, input + expected);
+    await assertOutputInTerminal(page, input + expected);
   });
 
   test("should output file not found error multiple times, when multiple file paths for non-existent paths is given", async ({
@@ -122,7 +122,7 @@ test.describe("Cat", () => {
     const expectedFirst = `cat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
     const expectedSecond = `cat: ${fakeFiles[1].resolvedPath}: No such file or directory`;
     const expected = `\n${expectedFirst}\n${expectedSecond}`;
-    await assertExactTextInTerminal(page, input + expected);
+    await assertOutputInTerminal(page, input + expected);
   });
 
   test("should output file not found error and found file contents, when multiple existent and non-existent file paths are given", async ({
@@ -138,7 +138,7 @@ test.describe("Cat", () => {
     const expectedFirst = `cat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
     const expectedSecond = existingFiles[0].content;
     const expected = `\n${expectedFirst}\n${expectedSecond}`;
-    await assertExactTextInTerminal(page, input + expected);
+    await assertOutputInTerminal(page, input + expected);
   });
 
   test("should output an 'a' element when reading a file with a Markdown URL", async ({
@@ -152,7 +152,7 @@ test.describe("Cat", () => {
 
     // Assert
     const expected = `\n${urlFiles[0].text}`;
-    await assertExactTextInTerminal(page, input + expected);
+    await assertOutputInTerminal(page, input + expected);
 
     const link = page
       .locator(OUTPUT_SELECTOR)

--- a/test/e2e/spec/command/cat.spec.ts
+++ b/test/e2e/spec/command/cat.spec.ts
@@ -1,11 +1,9 @@
 import { expect, test } from "../../fixture";
+import { OUTPUT_SELECTOR } from "../../helper/constant/generic";
 import {
-  DEFAULT_INITIAL_PROMPT,
-  DEFAULT_USER_PROMPT,
-  INPUT_SELECTOR,
-  OUTPUT_SELECTOR,
-  PROMPT_SELECTOR,
-} from "../../helper/constant/generic";
+  assertExactTextInTerminal,
+  runCommand,
+} from "../../helper/util/terminal_util.ts";
 
 test.describe("Cat", () => {
   const existingFiles = [
@@ -34,7 +32,8 @@ test.describe("Cat", () => {
         "| Geography                          | 6     | AQA             | 601/8410/3 |\n" +
         "| English Literature                 | 6     | AQA             | 601/4447/6 |\n" +
         "| English Language                   | 5     | AQA             | 601/4292/3 |\n" +
-        "| English Language (Spoken Language) | Merit | AQA             | 601/4292/3 |\n",
+        "| English Language (Spoken Language) | Merit | AQA             | 601/4292/3 |\n" +
+        " ",
     },
   ];
 
@@ -62,17 +61,10 @@ test.describe("Cat", () => {
     const input = "cat";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    await assertExactTextInTerminal(page, input);
   });
 
   test("should output the contents of a single file, when that file path is given", async ({
@@ -82,19 +74,11 @@ test.describe("Cat", () => {
     const input = `cat ${existingFiles[0].path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    const expected = existingFiles[0].content;
-
-    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expected}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    const expected = `\n${existingFiles[0].content}`;
+    await assertExactTextInTerminal(page, input + expected);
   });
 
   test("should output the contents of a multiple files, when multiple file paths are given", async ({
@@ -104,17 +88,11 @@ test.describe("Cat", () => {
     const input = `cat ${existingFiles[0].path} ${existingFiles[1].path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${existingFiles[0].content}\n${existingFiles[1].content}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    const expected = `\n${existingFiles[0].content}\n${existingFiles[1].content}`;
+    await assertExactTextInTerminal(page, input + expected);
   });
 
   test("should output file not found error, when a file path for a non-existent path is given", async ({
@@ -124,19 +102,11 @@ test.describe("Cat", () => {
     const input = `cat ${fakeFiles[0].path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    const expected = `cat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
-
-    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expected}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    const expected = `\ncat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
+    await assertExactTextInTerminal(page, input + expected);
   });
 
   test("should output file not found error multiple times, when multiple file paths for non-existent paths is given", async ({
@@ -146,20 +116,13 @@ test.describe("Cat", () => {
     const input = `cat ${fakeFiles[0].path} ${fakeFiles[1].path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
     const expectedFirst = `cat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
     const expectedSecond = `cat: ${fakeFiles[1].resolvedPath}: No such file or directory`;
-
-    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expectedFirst}\n${expectedSecond}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    const expected = `\n${expectedFirst}\n${expectedSecond}`;
+    await assertExactTextInTerminal(page, input + expected);
   });
 
   test("should output file not found error and found file contents, when multiple existent and non-existent file paths are given", async ({
@@ -169,20 +132,13 @@ test.describe("Cat", () => {
     const input = `cat ${fakeFiles[0].path} ${existingFiles[0].path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
     const expectedFirst = `cat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
     const expectedSecond = existingFiles[0].content;
-
-    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expectedFirst}\n${expectedSecond}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    const expected = `\n${expectedFirst}\n${expectedSecond}`;
+    await assertExactTextInTerminal(page, input + expected);
   });
 
   test("should output an 'a' element when reading a file with a Markdown URL", async ({
@@ -192,19 +148,11 @@ test.describe("Cat", () => {
     const input = `cat ${urlFiles[0].path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    const expected = urlFiles[0].text;
-
-    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expected}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    const expected = `\n${urlFiles[0].text}`;
+    await assertExactTextInTerminal(page, input + expected);
 
     const link = page
       .locator(OUTPUT_SELECTOR)

--- a/test/e2e/spec/command/cat.spec.ts
+++ b/test/e2e/spec/command/cat.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "../../fixture";
 import {
-  defaultInitialPrompt,
-  defaultUserPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  DEFAULT_INITIAL_PROMPT,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../../helper/constant/generic";
 
 test.describe("Cat", () => {
@@ -62,17 +62,17 @@ test.describe("Cat", () => {
     const input = "cat";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).elementToStartWith(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("should output the contents of a single file, when that file path is given", async ({
@@ -82,19 +82,19 @@ test.describe("Cat", () => {
     const input = `cat ${existingFiles[0].path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expected = existingFiles[0].content;
 
-    await expect(page.locator(outputSelector)).elementToStartWith(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${expected}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expected}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("should output the contents of a multiple files, when multiple file paths are given", async ({
@@ -104,17 +104,17 @@ test.describe("Cat", () => {
     const input = `cat ${existingFiles[0].path} ${existingFiles[1].path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).elementToStartWith(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${existingFiles[0].content}\n${existingFiles[1].content}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${existingFiles[0].content}\n${existingFiles[1].content}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("should output file not found error, when a file path for a non-existent path is given", async ({
@@ -124,19 +124,19 @@ test.describe("Cat", () => {
     const input = `cat ${fakeFiles[0].path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expected = `cat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
 
-    await expect(page.locator(outputSelector)).elementToStartWith(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${expected}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expected}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("should output file not found error multiple times, when multiple file paths for non-existent paths is given", async ({
@@ -146,20 +146,20 @@ test.describe("Cat", () => {
     const input = `cat ${fakeFiles[0].path} ${fakeFiles[1].path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expectedFirst = `cat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
     const expectedSecond = `cat: ${fakeFiles[1].resolvedPath}: No such file or directory`;
 
-    await expect(page.locator(outputSelector)).elementToStartWith(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${expectedFirst}\n${expectedSecond}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expectedFirst}\n${expectedSecond}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("should output file not found error and found file contents, when multiple existent and non-existent file paths are given", async ({
@@ -169,20 +169,20 @@ test.describe("Cat", () => {
     const input = `cat ${fakeFiles[0].path} ${existingFiles[0].path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expectedFirst = `cat: ${fakeFiles[0].resolvedPath}: No such file or directory`;
     const expectedSecond = existingFiles[0].content;
 
-    await expect(page.locator(outputSelector)).elementToStartWith(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${expectedFirst}\n${expectedSecond}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expectedFirst}\n${expectedSecond}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("should output an 'a' element when reading a file with a Markdown URL", async ({
@@ -192,22 +192,22 @@ test.describe("Cat", () => {
     const input = `cat ${urlFiles[0].path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expected = urlFiles[0].text;
 
-    await expect(page.locator(outputSelector)).elementToStartWith(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${expected}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expected}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
     const link = page
-      .locator(outputSelector)
+      .locator(OUTPUT_SELECTOR)
       .locator(`a[href="${urlFiles[0].href}"]`, { hasText: urlFiles[0].text });
     await expect(link).toHaveCount(1);
     await expect(link).toBeVisible();

--- a/test/e2e/spec/command/cd.spec.ts
+++ b/test/e2e/spec/command/cd.spec.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "../../fixture";
 import {
-  defaultCurrentWorkingDirectory,
-  defaultHomeDirectory,
-  defaultInitialPrompt,
-  defaultUserPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  DEFAULT_CURRENT_WORKING_DIRECTORY,
+  DEFAULT_HOME_DIRECTORY,
+  DEFAULT_INITIAL_PROMPT,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../../helper/constant/generic";
 import { Page } from "@playwright/test";
 import { getExpectedPrompt } from "../../helper/util/terminal_util";
@@ -15,20 +15,20 @@ async function checkCurrentWorkingDirectory(
   page: Page,
   expectedCurrentWorkingDirectory: string,
 ) {
-  const previousOutput = await page.locator(outputSelector).textContent();
-  const previousPrompt = await page.locator(promptSelector).textContent();
+  const previousOutput = await page.locator(OUTPUT_SELECTOR).textContent();
+  const previousPrompt = await page.locator(PROMPT_SELECTOR).textContent();
 
   const pwd = "pwd";
-  await page.locator(inputSelector).pressSequentially(pwd);
-  await page.locator(inputSelector).press("Enter");
+  await page.locator(INPUT_SELECTOR).pressSequentially(pwd);
+  await page.locator(INPUT_SELECTOR).press("Enter");
 
-  await expect(page.locator(outputSelector)).elementToStartWith(
+  await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
     `${previousOutput}\n${previousPrompt}${pwd}\n${expectedCurrentWorkingDirectory}`,
   );
-  await expect(page.locator(promptSelector)).exactTextInElement(
+  await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
     getExpectedPrompt(expectedCurrentWorkingDirectory),
   );
-  await expect(page.locator(inputSelector)).exactTextInElement("");
+  await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 }
 
 test.describe("Cd", () => {
@@ -40,17 +40,17 @@ test.describe("Cd", () => {
     const input = `cd ${path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
       getExpectedPrompt(path),
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
     await checkCurrentWorkingDirectory(page, path);
   });
@@ -62,19 +62,19 @@ test.describe("Cd", () => {
     const input = "cd";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      getExpectedPrompt(defaultHomeDirectory),
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      getExpectedPrompt(DEFAULT_HOME_DIRECTORY),
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
-    await checkCurrentWorkingDirectory(page, defaultHomeDirectory);
+    await checkCurrentWorkingDirectory(page, DEFAULT_HOME_DIRECTORY);
   });
 
   test("should change directory to the previous working directory when a previous working directory exists and '-' is provided as a path", async ({
@@ -85,31 +85,31 @@ test.describe("Cd", () => {
     const currentWorkingDirectory = "/home";
 
     await page
-      .locator(inputSelector)
+      .locator(INPUT_SELECTOR)
       .pressSequentially(`cd ${previousWorkingDirectory}`);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     await page
-      .locator(inputSelector)
+      .locator(INPUT_SELECTOR)
       .pressSequentially(`cd ${currentWorkingDirectory}`);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Act
-    await page.locator(inputSelector).pressSequentially("cd -");
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially("cd -");
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}` +
-        `\n${defaultUserPrompt}cd ${previousWorkingDirectory}` +
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}` +
+        `\n${DEFAULT_USER_PROMPT}cd ${previousWorkingDirectory}` +
         `\n${getExpectedPrompt(previousWorkingDirectory)}cd ${currentWorkingDirectory}` +
         `\n${getExpectedPrompt(currentWorkingDirectory)}cd -` +
         `\n${previousWorkingDirectory}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
       getExpectedPrompt(previousWorkingDirectory),
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
     await checkCurrentWorkingDirectory(page, previousWorkingDirectory);
   });
@@ -126,21 +126,21 @@ test.describe("Cd", () => {
       "/etc/opt",
     ];
     const previousWorkingDirectory = directories[directories.length - 2];
-    let previousDirectory = defaultCurrentWorkingDirectory;
+    let previousDirectory = DEFAULT_CURRENT_WORKING_DIRECTORY;
 
     for (const directory of directories) {
-      const previousOutput = await page.locator(outputSelector).textContent();
+      const previousOutput = await page.locator(OUTPUT_SELECTOR).textContent();
 
-      await page.locator(inputSelector).pressSequentially(`cd ${directory}`);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(`cd ${directory}`);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
-      await expect(page.locator(outputSelector)).exactTextInElement(
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
         `${previousOutput}\n${getExpectedPrompt(previousDirectory)}cd ${directory}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
         getExpectedPrompt(directory),
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       previousDirectory = directory;
 
@@ -148,20 +148,20 @@ test.describe("Cd", () => {
     }
 
     const input = "cd -";
-    const previousOutput = await page.locator(outputSelector).textContent();
+    const previousOutput = await page.locator(OUTPUT_SELECTOR).textContent();
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
       `${previousOutput}\n${getExpectedPrompt(previousDirectory)}${input}\n${previousWorkingDirectory}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
       getExpectedPrompt(previousWorkingDirectory),
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
     await checkCurrentWorkingDirectory(page, previousWorkingDirectory);
   });
@@ -173,19 +173,19 @@ test.describe("Cd", () => {
     const input = "cd /var/tmp /home/nathanwise";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\nbash: cd: too many arguments`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: too many arguments`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
-    await checkCurrentWorkingDirectory(page, defaultCurrentWorkingDirectory);
+    await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 
   test("should output an error message when no previous working directory exists and '-' is provided as a path", async ({
@@ -195,19 +195,19 @@ test.describe("Cd", () => {
     const input = "cd -";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\nbash: cd: OLDPWD not set`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: OLDPWD not set`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
-    await checkCurrentWorkingDirectory(page, defaultCurrentWorkingDirectory);
+    await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 
   test("should output an error message when a file path is provided", async ({
@@ -218,19 +218,19 @@ test.describe("Cd", () => {
     const input = `cd ${path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\nbash: cd: ${path}: Not a directory`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: ${path}: Not a directory`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
-    await checkCurrentWorkingDirectory(page, defaultCurrentWorkingDirectory);
+    await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 
   test("should output an error message when a non-existent directory path is provided", async ({
@@ -241,19 +241,19 @@ test.describe("Cd", () => {
     const input = `cd ${path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\nbash: cd: ${path}: No such file or directory`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: ${path}: No such file or directory`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
-    await checkCurrentWorkingDirectory(page, defaultCurrentWorkingDirectory);
+    await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 
   test("should output an error message when an unresolvable directory path is provided", async ({
@@ -264,18 +264,18 @@ test.describe("Cd", () => {
     const input = `cd ${path}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\nbash: cd: ${path}: No such file or directory`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: ${path}: No such file or directory`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
-    await checkCurrentWorkingDirectory(page, defaultCurrentWorkingDirectory);
+    await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 });

--- a/test/e2e/spec/command/cd.spec.ts
+++ b/test/e2e/spec/command/cd.spec.ts
@@ -9,7 +9,11 @@ import {
   PROMPT_SELECTOR,
 } from "../../helper/constant/generic";
 import { Page } from "@playwright/test";
-import { getExpectedPrompt } from "../../helper/util/terminal_util";
+import {
+  assertExactTextInTerminal,
+  getExpectedPrompt,
+  runCommand,
+} from "../../helper/util/terminal_util";
 
 async function checkCurrentWorkingDirectory(
   page: Page,
@@ -18,12 +22,11 @@ async function checkCurrentWorkingDirectory(
   const previousOutput = await page.locator(OUTPUT_SELECTOR).textContent();
   const previousPrompt = await page.locator(PROMPT_SELECTOR).textContent();
 
-  const pwd = "pwd";
-  await page.locator(INPUT_SELECTOR).pressSequentially(pwd);
-  await page.locator(INPUT_SELECTOR).press("Enter");
+  const input = "pwd";
+  await runCommand(page, input);
 
   await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-    `${previousOutput}\n${previousPrompt}${pwd}\n${expectedCurrentWorkingDirectory}`,
+    `${previousOutput}\n${previousPrompt}${input}\n${expectedCurrentWorkingDirectory}`,
   );
   await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
     getExpectedPrompt(expectedCurrentWorkingDirectory),
@@ -40,18 +43,15 @@ test.describe("Cd", () => {
     const input = `cd ${path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+    await assertExactTextInTerminal(
+      page,
+      input,
+      undefined,
       getExpectedPrompt(path),
     );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
     await checkCurrentWorkingDirectory(page, path);
   });
 
@@ -62,18 +62,15 @@ test.describe("Cd", () => {
     const input = "cd";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+    await assertExactTextInTerminal(
+      page,
+      input,
+      undefined,
       getExpectedPrompt(DEFAULT_HOME_DIRECTORY),
     );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
     await checkCurrentWorkingDirectory(page, DEFAULT_HOME_DIRECTORY);
   });
 
@@ -84,33 +81,26 @@ test.describe("Cd", () => {
     const previousWorkingDirectory = "/var/tmp";
     const currentWorkingDirectory = "/home";
 
-    await page
-      .locator(INPUT_SELECTOR)
-      .pressSequentially(`cd ${previousWorkingDirectory}`);
-    await page.locator(INPUT_SELECTOR).press("Enter");
-
-    await page
-      .locator(INPUT_SELECTOR)
-      .pressSequentially(`cd ${currentWorkingDirectory}`);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, `cd ${previousWorkingDirectory}`);
+    await runCommand(page, `cd ${currentWorkingDirectory}`);
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially("cd -");
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, "cd -");
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+    const expectedOutputText =
       `${DEFAULT_INITIAL_PROMPT}` +
-        `\n${DEFAULT_USER_PROMPT}cd ${previousWorkingDirectory}` +
-        `\n${getExpectedPrompt(previousWorkingDirectory)}cd ${currentWorkingDirectory}` +
-        `\n${getExpectedPrompt(currentWorkingDirectory)}cd -` +
-        `\n${previousWorkingDirectory}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      `\n${DEFAULT_USER_PROMPT}cd ${previousWorkingDirectory}` +
+      `\n${getExpectedPrompt(previousWorkingDirectory)}cd ${currentWorkingDirectory}` +
+      `\n${getExpectedPrompt(currentWorkingDirectory)}cd -` +
+      `\n${previousWorkingDirectory}`;
+
+    await assertExactTextInTerminal(
+      page,
+      "",
+      expectedOutputText,
       getExpectedPrompt(previousWorkingDirectory),
     );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
     await checkCurrentWorkingDirectory(page, previousWorkingDirectory);
   });
 
@@ -131,16 +121,15 @@ test.describe("Cd", () => {
     for (const directory of directories) {
       const previousOutput = await page.locator(OUTPUT_SELECTOR).textContent();
 
-      await page.locator(INPUT_SELECTOR).pressSequentially(`cd ${directory}`);
-      await page.locator(INPUT_SELECTOR).press("Enter");
+      await runCommand(page, `cd ${directory}`);
 
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${previousOutput}\n${getExpectedPrompt(previousDirectory)}cd ${directory}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      const expectedOutputText = `${previousOutput}\n${getExpectedPrompt(previousDirectory)}cd ${directory}`;
+      await assertExactTextInTerminal(
+        page,
+        "",
+        expectedOutputText,
         getExpectedPrompt(directory),
       );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       previousDirectory = directory;
 
@@ -151,18 +140,16 @@ test.describe("Cd", () => {
     const previousOutput = await page.locator(OUTPUT_SELECTOR).textContent();
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${previousOutput}\n${getExpectedPrompt(previousDirectory)}${input}\n${previousWorkingDirectory}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+    const expectedOutputText = `${previousOutput}\n${getExpectedPrompt(previousDirectory)}${input}\n${previousWorkingDirectory}`;
+    await assertExactTextInTerminal(
+      page,
+      "",
+      expectedOutputText,
       getExpectedPrompt(previousWorkingDirectory),
     );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
     await checkCurrentWorkingDirectory(page, previousWorkingDirectory);
   });
 
@@ -173,18 +160,13 @@ test.describe("Cd", () => {
     const input = "cd /var/tmp /home/nathanwise";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: too many arguments`,
+    await assertExactTextInTerminal(
+      page,
+      `${input}\nbash: cd: too many arguments`,
     );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
     await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 
@@ -195,18 +177,10 @@ test.describe("Cd", () => {
     const input = "cd -";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: OLDPWD not set`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+    await assertExactTextInTerminal(page, `${input}\nbash: cd: OLDPWD not set`);
     await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 
@@ -218,18 +192,13 @@ test.describe("Cd", () => {
     const input = `cd ${path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: ${path}: Not a directory`,
+    await assertExactTextInTerminal(
+      page,
+      `${input}\nbash: cd: ${path}: Not a directory`,
     );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
     await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 
@@ -241,18 +210,13 @@ test.describe("Cd", () => {
     const input = `cd ${path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: ${path}: No such file or directory`,
+    await assertExactTextInTerminal(
+      page,
+      `${input}\nbash: cd: ${path}: No such file or directory`,
     );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
     await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 
@@ -264,18 +228,13 @@ test.describe("Cd", () => {
     const input = `cd ${path}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\nbash: cd: ${path}: No such file or directory`,
+    await assertExactTextInTerminal(
+      page,
+      `${input}\nbash: cd: ${path}: No such file or directory`,
     );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
     await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 });

--- a/test/e2e/spec/command/cd.spec.ts
+++ b/test/e2e/spec/command/cd.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "../../fixture";
 import {
+  COMMAND_RAN_OUTPUT,
   DEFAULT_CURRENT_WORKING_DIRECTORY,
   DEFAULT_HOME_DIRECTORY,
   DEFAULT_INITIAL_PROMPT,
@@ -11,6 +12,7 @@ import {
 import { Page } from "@playwright/test";
 import {
   assertExactTextInTerminal,
+  assertOutputInTerminal,
   getExpectedPrompt,
   runCommand,
 } from "../../helper/util/terminal_util";
@@ -48,8 +50,7 @@ test.describe("Cd", () => {
     // Assert
     await assertExactTextInTerminal(
       page,
-      input,
-      undefined,
+      COMMAND_RAN_OUTPUT + input,
       getExpectedPrompt(path),
     );
     await checkCurrentWorkingDirectory(page, path);
@@ -67,8 +68,7 @@ test.describe("Cd", () => {
     // Assert
     await assertExactTextInTerminal(
       page,
-      input,
-      undefined,
+      COMMAND_RAN_OUTPUT + input,
       getExpectedPrompt(DEFAULT_HOME_DIRECTORY),
     );
     await checkCurrentWorkingDirectory(page, DEFAULT_HOME_DIRECTORY);
@@ -97,7 +97,6 @@ test.describe("Cd", () => {
 
     await assertExactTextInTerminal(
       page,
-      "",
       expectedOutputText,
       getExpectedPrompt(previousWorkingDirectory),
     );
@@ -126,7 +125,6 @@ test.describe("Cd", () => {
       const expectedOutputText = `${previousOutput}\n${getExpectedPrompt(previousDirectory)}cd ${directory}`;
       await assertExactTextInTerminal(
         page,
-        "",
         expectedOutputText,
         getExpectedPrompt(directory),
       );
@@ -146,7 +144,6 @@ test.describe("Cd", () => {
     const expectedOutputText = `${previousOutput}\n${getExpectedPrompt(previousDirectory)}${input}\n${previousWorkingDirectory}`;
     await assertExactTextInTerminal(
       page,
-      "",
       expectedOutputText,
       getExpectedPrompt(previousWorkingDirectory),
     );
@@ -163,7 +160,7 @@ test.describe("Cd", () => {
     await runCommand(page, input);
 
     // Assert
-    await assertExactTextInTerminal(
+    await assertOutputInTerminal(
       page,
       `${input}\nbash: cd: too many arguments`,
     );
@@ -180,7 +177,7 @@ test.describe("Cd", () => {
     await runCommand(page, input);
 
     // Assert
-    await assertExactTextInTerminal(page, `${input}\nbash: cd: OLDPWD not set`);
+    await assertOutputInTerminal(page, `${input}\nbash: cd: OLDPWD not set`);
     await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
   });
 
@@ -195,7 +192,7 @@ test.describe("Cd", () => {
     await runCommand(page, input);
 
     // Assert
-    await assertExactTextInTerminal(
+    await assertOutputInTerminal(
       page,
       `${input}\nbash: cd: ${path}: Not a directory`,
     );
@@ -213,7 +210,7 @@ test.describe("Cd", () => {
     await runCommand(page, input);
 
     // Assert
-    await assertExactTextInTerminal(
+    await assertOutputInTerminal(
       page,
       `${input}\nbash: cd: ${path}: No such file or directory`,
     );
@@ -231,7 +228,7 @@ test.describe("Cd", () => {
     await runCommand(page, input);
 
     // Assert
-    await assertExactTextInTerminal(
+    await assertOutputInTerminal(
       page,
       `${input}\nbash: cd: ${path}: No such file or directory`,
     );

--- a/test/e2e/spec/command/clear.spec.ts
+++ b/test/e2e/spec/command/clear.spec.ts
@@ -1,11 +1,12 @@
-import { expect, test } from "../../fixture";
+import { test } from "../../fixture";
 import {
   COMMAND_NOT_FOUND,
   DEFAULT_USER_PROMPT,
-  INPUT_SELECTOR,
-  OUTPUT_SELECTOR,
-  PROMPT_SELECTOR,
 } from "../../helper/constant/generic";
+import {
+  assertExactTextInTerminal,
+  runCommand,
+} from "../../helper/util/terminal_util.ts";
 
 test.describe("Clear", () => {
   test("should remove all existing outputs", async ({ page }) => {
@@ -14,20 +15,11 @@ test.describe("Clear", () => {
     const input = "clear";
 
     // Act
-    // Rubbish input first to simulate terminal usage
-    await page.locator(INPUT_SELECTOR).pressSequentially(defaultInput);
-    await page.locator(INPUT_SELECTOR).press("Enter");
-
-    // Actual clear
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, defaultInput); // Rubbish input first to simulate terminal usage
+    await runCommand(page, input); // actual clear
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement("");
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    await assertExactTextInTerminal(page, "", "", undefined, "");
   });
 
   test("output must not have an extra newline after clearing", async ({
@@ -37,18 +29,11 @@ test.describe("Clear", () => {
     const fakeCommand = "fakecommand";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially("clear");
-    await page.locator(INPUT_SELECTOR).press("Enter");
-    await page.locator(INPUT_SELECTOR).pressSequentially(fakeCommand);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, "clear");
+    await runCommand(page, fakeCommand);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_USER_PROMPT}${fakeCommand}\n${fakeCommand}${COMMAND_NOT_FOUND}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    const fullExpected = `${DEFAULT_USER_PROMPT}${fakeCommand}\n${fakeCommand}${COMMAND_NOT_FOUND}`;
+    await assertExactTextInTerminal(page, "", fullExpected);
   });
 });

--- a/test/e2e/spec/command/clear.spec.ts
+++ b/test/e2e/spec/command/clear.spec.ts
@@ -19,7 +19,7 @@ test.describe("Clear", () => {
     await runCommand(page, input); // actual clear
 
     // Assert
-    await assertExactTextInTerminal(page, "", "", undefined, "");
+    await assertExactTextInTerminal(page, "", undefined, "");
   });
 
   test("output must not have an extra newline after clearing", async ({
@@ -34,6 +34,6 @@ test.describe("Clear", () => {
 
     // Assert
     const fullExpected = `${DEFAULT_USER_PROMPT}${fakeCommand}\n${fakeCommand}${COMMAND_NOT_FOUND}`;
-    await assertExactTextInTerminal(page, "", fullExpected);
+    await assertExactTextInTerminal(page, fullExpected);
   });
 });

--- a/test/e2e/spec/command/clear.spec.ts
+++ b/test/e2e/spec/command/clear.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "../../fixture";
 import {
-  commandNotFound,
-  defaultUserPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  COMMAND_NOT_FOUND,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../../helper/constant/generic";
 
 test.describe("Clear", () => {
@@ -15,19 +15,19 @@ test.describe("Clear", () => {
 
     // Act
     // Rubbish input first to simulate terminal usage
-    await page.locator(inputSelector).pressSequentially(defaultInput);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(defaultInput);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Actual clear
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement("");
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement("");
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("output must not have an extra newline after clearing", async ({
@@ -37,18 +37,18 @@ test.describe("Clear", () => {
     const fakeCommand = "fakecommand";
 
     // Act
-    await page.locator(inputSelector).pressSequentially("clear");
-    await page.locator(inputSelector).press("Enter");
-    await page.locator(inputSelector).pressSequentially(fakeCommand);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially("clear");
+    await page.locator(INPUT_SELECTOR).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(fakeCommand);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultUserPrompt}${fakeCommand}\n${fakeCommand}${commandNotFound}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_USER_PROMPT}${fakeCommand}\n${fakeCommand}${COMMAND_NOT_FOUND}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 });

--- a/test/e2e/spec/command/echo.spec.ts
+++ b/test/e2e/spec/command/echo.spec.ts
@@ -1,11 +1,8 @@
-import { expect, test } from "../../fixture";
+import { test } from "../../fixture";
 import {
-  DEFAULT_USER_PROMPT,
-  DEFAULT_INITIAL_PROMPT,
-  INPUT_SELECTOR,
-  OUTPUT_SELECTOR,
-  PROMPT_SELECTOR,
-} from "../../helper/constant/generic";
+  assertExactTextInTerminal,
+  runCommand,
+} from "../../helper/util/terminal_util.ts";
 
 test.describe("Echo", () => {
   test("should output all non-option arguments", async ({ page }) => {
@@ -13,19 +10,11 @@ test.describe("Echo", () => {
     const input = "echo foo bar -e baz gaz";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
     const expected = "foo bar gaz";
-
-    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expected}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    await assertExactTextInTerminal(page, `${input}\n${expected}`);
   });
 
   test("should output nothing when nothing is provided", async ({ page }) => {
@@ -33,16 +22,9 @@ test.describe("Echo", () => {
     const input = "echo ";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+    await assertExactTextInTerminal(page, `${input}\n`);
   });
 });

--- a/test/e2e/spec/command/echo.spec.ts
+++ b/test/e2e/spec/command/echo.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "../../fixture";
 import {
-  defaultUserPrompt,
-  defaultInitialPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  DEFAULT_USER_PROMPT,
+  DEFAULT_INITIAL_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../../helper/constant/generic";
 
 test.describe("Echo", () => {
@@ -13,19 +13,19 @@ test.describe("Echo", () => {
     const input = "echo foo bar -e baz gaz";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expected = "foo bar gaz";
 
-    await expect(page.locator(outputSelector)).elementToStartWith(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${expected}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${expected}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("should output nothing when nothing is provided", async ({ page }) => {
@@ -33,16 +33,16 @@ test.describe("Echo", () => {
     const input = "echo ";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).elementToStartWith(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).elementToStartWith(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 });

--- a/test/e2e/spec/command/echo.spec.ts
+++ b/test/e2e/spec/command/echo.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "../../fixture";
 import {
-  assertExactTextInTerminal,
+  assertOutputInTerminal,
   runCommand,
 } from "../../helper/util/terminal_util.ts";
 
@@ -14,7 +14,7 @@ test.describe("Echo", () => {
 
     // Assert
     const expected = "foo bar gaz";
-    await assertExactTextInTerminal(page, `${input}\n${expected}`);
+    await assertOutputInTerminal(page, `${input}\n${expected}`);
   });
 
   test("should output nothing when nothing is provided", async ({ page }) => {
@@ -25,6 +25,6 @@ test.describe("Echo", () => {
     await runCommand(page, input);
 
     // Assert
-    await assertExactTextInTerminal(page, `${input}\n`);
+    await assertOutputInTerminal(page, `${input}\n`);
   });
 });

--- a/test/e2e/spec/command/ls.spec.ts
+++ b/test/e2e/spec/command/ls.spec.ts
@@ -2,7 +2,7 @@ import { test } from "../../fixture";
 import { INPUT_SELECTOR } from "../../helper/constant/generic";
 import { checkForColouredSpans } from "../../helper/util/element_util.ts";
 import {
-  assertExactTextInTerminal,
+  assertOutputInTerminal,
   runCommand,
 } from "../../helper/util/terminal_util.ts";
 
@@ -123,7 +123,7 @@ test.describe("Ls", () => {
       await runCommand(page, input);
 
       // Assert
-      await assertExactTextInTerminal(page, `${input}${expected}`);
+      await assertOutputInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, counts);
     });
   });
@@ -146,7 +146,7 @@ test.describe("Ls", () => {
           "\n/etc/hosts\t/home/nathanwise/Projects/this/.external" +
           "\n\n/home/nathanwise/Documents:" +
           "\n.\t..\tabout.txt\tCV.pdf\tEducation\tskills.md\t.tmp";
-        await assertExactTextInTerminal(page, `${input}${expected}`);
+        await assertOutputInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 3,
           executables: 0,
@@ -175,7 +175,7 @@ test.describe("Ls", () => {
       "\n/etc/hosts\n/home/nathanwise/Projects/this/.external" +
       "\n\n/home/nathanwise/Documents:" +
       "\nabout.txt\nCV.pdf\nEducation\nskills.md";
-    await assertExactTextInTerminal(page, `${input}${expected}`);
+    await assertOutputInTerminal(page, `${input}${expected}`);
     await checkForColouredSpans(page, {
       directory: 1,
       executables: 0,
@@ -205,7 +205,7 @@ test.describe("Ls", () => {
           "/home/nathanwise/Documents:\n" +
           "total: 320\n" +
           "12 about.txt\t292 CV.pdf\t4 Education\t12 skills.md";
-        await assertExactTextInTerminal(page, `${input}${expected}`);
+        await assertOutputInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 1,
           executables: 0,
@@ -233,7 +233,7 @@ test.describe("Ls", () => {
           "/home/nathanwise/Documents:\n" +
           "total: 340\n" +
           "4 .\t4 ..\t12 about.txt\t292 CV.pdf\t4 Education\t12 skills.md\t12 .tmp";
-        await assertExactTextInTerminal(page, `${input}${expected}`);
+        await assertOutputInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 3,
           executables: 0,
@@ -265,7 +265,7 @@ test.describe("Ls", () => {
           "/home/nathanwise/Documents:\n" +
           "total: 320K\n" +
           "12K about.txt\t292K CV.pdf\t4K Education\t12K skills.md";
-        await assertExactTextInTerminal(page, `${input}${expected}`);
+        await assertOutputInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 1,
           executables: 0,
@@ -297,7 +297,7 @@ test.describe("Ls", () => {
           "\n-rw-rw-r-- 1 nathanwise nathanwise\t282K Jul 21 00:50 CV.pdf" +
           "\ndrwxrwxr-x 2 nathanwise nathanwise\t4K Aug 17 00:33 Education" +
           "\n-rw-rw-r-- 1 nathanwise nathanwise\t1K Jul 21 00:50 skills.md";
-        await assertExactTextInTerminal(page, `${input}${expected}`);
+        await assertOutputInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 1,
           executables: 0,
@@ -326,7 +326,7 @@ test.describe("Ls", () => {
         "\n/etc/hosts\t/home/nathanwise/Projects/this/.external" +
         "\n\n/home/nathanwise/Documents:" +
         "\nabout.txt\tCV.pdf\tEducation\tskills.md";
-      await assertExactTextInTerminal(page, `${input}${expected}`);
+      await assertOutputInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 1,
         executables: 0,
@@ -446,7 +446,7 @@ test.describe("Ls", () => {
       await runCommand(page, input);
 
       // Assert
-      await assertExactTextInTerminal(page, `${input}${expected}`);
+      await assertOutputInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 1,
         executables: 0,
@@ -479,7 +479,7 @@ test.describe("Ls", () => {
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t288626 Jul 21 00:50 CV.pdf" +
         "\ndrwxrwxr-x 2 nathanwise nathanwise\t4096 Aug 17 00:33 Education" +
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t375 Jul 21 00:50 skills.md";
-      await assertExactTextInTerminal(page, `${input}${expected}`);
+      await assertOutputInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 1,
         executables: 0,
@@ -508,7 +508,7 @@ test.describe("Ls", () => {
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t288626 Jul 21 00:50 CV.pdf" +
         "\ndrwxrwxr-x 2 nathanwise nathanwise\t4096 Aug 17 00:33 Education" +
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t375 Jul 21 00:50 skills.md";
-      await assertExactTextInTerminal(page, `${input}${expected}`);
+      await assertOutputInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 1,
         executables: 0,

--- a/test/e2e/spec/command/ls.spec.ts
+++ b/test/e2e/spec/command/ls.spec.ts
@@ -1,12 +1,10 @@
-import { expect, test } from "../../fixture";
-import {
-  DEFAULT_INITIAL_PROMPT,
-  DEFAULT_USER_PROMPT,
-  INPUT_SELECTOR,
-  OUTPUT_SELECTOR,
-  PROMPT_SELECTOR,
-} from "../../helper/constant/generic";
+import { test } from "../../fixture";
+import { INPUT_SELECTOR } from "../../helper/constant/generic";
 import { checkForColouredSpans } from "../../helper/util/element_util.ts";
+import {
+  assertExactTextInTerminal,
+  runCommand,
+} from "../../helper/util/terminal_util.ts";
 
 test.describe("Ls", () => {
   const existingDirectory = "/home/nathanwise/Documents";
@@ -122,18 +120,10 @@ test.describe("Ls", () => {
       }
 
       // Act
-      await page.locator(INPUT_SELECTOR).pressSequentially(input);
-      await page.locator(INPUT_SELECTOR).press("Enter");
+      await runCommand(page, input);
 
       // Assert
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+      await assertExactTextInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, counts);
     });
   });
@@ -156,14 +146,7 @@ test.describe("Ls", () => {
           "\n/etc/hosts\t/home/nathanwise/Projects/this/.external" +
           "\n\n/home/nathanwise/Documents:" +
           "\n.\t..\tabout.txt\tCV.pdf\tEducation\tskills.md\t.tmp";
-        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-        );
-        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-          DEFAULT_USER_PROMPT,
-        );
-        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+        await assertExactTextInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 3,
           executables: 0,
@@ -192,14 +175,7 @@ test.describe("Ls", () => {
       "\n/etc/hosts\n/home/nathanwise/Projects/this/.external" +
       "\n\n/home/nathanwise/Documents:" +
       "\nabout.txt\nCV.pdf\nEducation\nskills.md";
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+    await assertExactTextInTerminal(page, `${input}${expected}`);
     await checkForColouredSpans(page, {
       directory: 1,
       executables: 0,
@@ -229,14 +205,7 @@ test.describe("Ls", () => {
           "/home/nathanwise/Documents:\n" +
           "total: 320\n" +
           "12 about.txt\t292 CV.pdf\t4 Education\t12 skills.md";
-        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-        );
-        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-          DEFAULT_USER_PROMPT,
-        );
-        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+        await assertExactTextInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 1,
           executables: 0,
@@ -264,14 +233,7 @@ test.describe("Ls", () => {
           "/home/nathanwise/Documents:\n" +
           "total: 340\n" +
           "4 .\t4 ..\t12 about.txt\t292 CV.pdf\t4 Education\t12 skills.md\t12 .tmp";
-        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-        );
-        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-          DEFAULT_USER_PROMPT,
-        );
-        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+        await assertExactTextInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 3,
           executables: 0,
@@ -303,14 +265,7 @@ test.describe("Ls", () => {
           "/home/nathanwise/Documents:\n" +
           "total: 320K\n" +
           "12K about.txt\t292K CV.pdf\t4K Education\t12K skills.md";
-        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-        );
-        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-          DEFAULT_USER_PROMPT,
-        );
-        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+        await assertExactTextInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 1,
           executables: 0,
@@ -342,14 +297,7 @@ test.describe("Ls", () => {
           "\n-rw-rw-r-- 1 nathanwise nathanwise\t282K Jul 21 00:50 CV.pdf" +
           "\ndrwxrwxr-x 2 nathanwise nathanwise\t4K Aug 17 00:33 Education" +
           "\n-rw-rw-r-- 1 nathanwise nathanwise\t1K Jul 21 00:50 skills.md";
-        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-        );
-        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-          DEFAULT_USER_PROMPT,
-        );
-        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+        await assertExactTextInTerminal(page, `${input}${expected}`);
         await checkForColouredSpans(page, {
           directory: 1,
           executables: 0,
@@ -370,8 +318,7 @@ test.describe("Ls", () => {
       const input = `ls --block-size=2048 ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
       // Act
-      await page.locator(INPUT_SELECTOR).pressSequentially(input);
-      await page.locator(INPUT_SELECTOR).press("Enter");
+      await runCommand(page, input);
 
       // Assert
       const expected =
@@ -379,14 +326,7 @@ test.describe("Ls", () => {
         "\n/etc/hosts\t/home/nathanwise/Projects/this/.external" +
         "\n\n/home/nathanwise/Documents:" +
         "\nabout.txt\tCV.pdf\tEducation\tskills.md";
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+      await assertExactTextInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 1,
         executables: 0,
@@ -503,18 +443,10 @@ test.describe("Ls", () => {
       const input = `ls ${flags.join(" ")} --block-size=${blockSize} ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
       // Act
-      await page.locator(INPUT_SELECTOR).pressSequentially(input);
-      await page.locator(INPUT_SELECTOR).press("Enter");
+      await runCommand(page, input);
 
       // Assert
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+      await assertExactTextInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 1,
         executables: 0,
@@ -534,8 +466,7 @@ test.describe("Ls", () => {
       const input = `ls -l ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
       // Act
-      await page.locator(INPUT_SELECTOR).pressSequentially(input);
-      await page.locator(INPUT_SELECTOR).press("Enter");
+      await runCommand(page, input);
 
       // Assert
       const expected =
@@ -548,14 +479,7 @@ test.describe("Ls", () => {
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t288626 Jul 21 00:50 CV.pdf" +
         "\ndrwxrwxr-x 2 nathanwise nathanwise\t4096 Aug 17 00:33 Education" +
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t375 Jul 21 00:50 skills.md";
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+      await assertExactTextInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 1,
         executables: 0,
@@ -571,8 +495,7 @@ test.describe("Ls", () => {
       const input = `ls -l ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
       // Act
-      await page.locator(INPUT_SELECTOR).pressSequentially(input);
-      await page.locator(INPUT_SELECTOR).press("Enter");
+      await runCommand(page, input);
 
       // Assert
       const expected =
@@ -585,14 +508,7 @@ test.describe("Ls", () => {
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t288626 Jul 21 00:50 CV.pdf" +
         "\ndrwxrwxr-x 2 nathanwise nathanwise\t4096 Aug 17 00:33 Education" +
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t375 Jul 21 00:50 skills.md";
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+      await assertExactTextInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 1,
         executables: 0,

--- a/test/e2e/spec/command/ls.spec.ts
+++ b/test/e2e/spec/command/ls.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "../../fixture";
 import {
-  defaultInitialPrompt,
-  defaultUserPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  DEFAULT_INITIAL_PROMPT,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../../helper/constant/generic";
 import { checkForColouredSpans } from "../../helper/util/element_util.ts";
 
@@ -122,17 +122,17 @@ test.describe("Ls", () => {
       }
 
       // Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       await checkForColouredSpans(page, counts);
     });
@@ -147,8 +147,8 @@ test.describe("Ls", () => {
         const input = `ls ${flag} ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
         // Act
-        await page.locator(inputSelector).pressSequentially(input);
-        await page.locator(inputSelector).press("Enter");
+        await page.locator(INPUT_SELECTOR).pressSequentially(input);
+        await page.locator(INPUT_SELECTOR).press("Enter");
 
         // Assert
         const expected =
@@ -156,13 +156,13 @@ test.describe("Ls", () => {
           "\n/etc/hosts\t/home/nathanwise/Projects/this/.external" +
           "\n\n/home/nathanwise/Documents:" +
           "\n.\t..\tabout.txt\tCV.pdf\tEducation\tskills.md\t.tmp";
-        await expect(page.locator(outputSelector)).exactTextInElement(
-          `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
         );
-        await expect(page.locator(promptSelector)).exactTextInElement(
-          defaultUserPrompt,
+        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+          DEFAULT_USER_PROMPT,
         );
-        await expect(page.locator(inputSelector)).exactTextInElement("");
+        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
         await checkForColouredSpans(page, {
           directory: 3,
@@ -183,8 +183,8 @@ test.describe("Ls", () => {
     const input = `ls -1 ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expected =
@@ -192,13 +192,13 @@ test.describe("Ls", () => {
       "\n/etc/hosts\n/home/nathanwise/Projects/this/.external" +
       "\n\n/home/nathanwise/Documents:" +
       "\nabout.txt\nCV.pdf\nEducation\nskills.md";
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
     await checkForColouredSpans(page, {
       directory: 1,
@@ -219,8 +219,8 @@ test.describe("Ls", () => {
         const input = `ls ${flag} ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
         // Act
-        await page.locator(inputSelector).pressSequentially(input);
-        await page.locator(inputSelector).press("Enter");
+        await page.locator(INPUT_SELECTOR).pressSequentially(input);
+        await page.locator(INPUT_SELECTOR).press("Enter");
 
         // Assert
         const expected =
@@ -229,13 +229,13 @@ test.describe("Ls", () => {
           "/home/nathanwise/Documents:\n" +
           "total: 320\n" +
           "12 about.txt\t292 CV.pdf\t4 Education\t12 skills.md";
-        await expect(page.locator(outputSelector)).exactTextInElement(
-          `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
         );
-        await expect(page.locator(promptSelector)).exactTextInElement(
-          defaultUserPrompt,
+        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+          DEFAULT_USER_PROMPT,
         );
-        await expect(page.locator(inputSelector)).exactTextInElement("");
+        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
         await checkForColouredSpans(page, {
           directory: 1,
@@ -254,8 +254,8 @@ test.describe("Ls", () => {
         const input = `ls ${flag} -a ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
         // Act
-        await page.locator(inputSelector).pressSequentially(input);
-        await page.locator(inputSelector).press("Enter");
+        await page.locator(INPUT_SELECTOR).pressSequentially(input);
+        await page.locator(INPUT_SELECTOR).press("Enter");
 
         // Assert
         const expected =
@@ -264,13 +264,13 @@ test.describe("Ls", () => {
           "/home/nathanwise/Documents:\n" +
           "total: 340\n" +
           "4 .\t4 ..\t12 about.txt\t292 CV.pdf\t4 Education\t12 skills.md\t12 .tmp";
-        await expect(page.locator(outputSelector)).exactTextInElement(
-          `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
         );
-        await expect(page.locator(promptSelector)).exactTextInElement(
-          defaultUserPrompt,
+        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+          DEFAULT_USER_PROMPT,
         );
-        await expect(page.locator(inputSelector)).exactTextInElement("");
+        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
         await checkForColouredSpans(page, {
           directory: 3,
@@ -293,8 +293,8 @@ test.describe("Ls", () => {
         const input = `ls -sh ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
         // Act
-        await page.locator(inputSelector).pressSequentially(input);
-        await page.locator(inputSelector).press("Enter");
+        await page.locator(INPUT_SELECTOR).pressSequentially(input);
+        await page.locator(INPUT_SELECTOR).press("Enter");
 
         // Assert
         const expected =
@@ -303,13 +303,13 @@ test.describe("Ls", () => {
           "/home/nathanwise/Documents:\n" +
           "total: 320K\n" +
           "12K about.txt\t292K CV.pdf\t4K Education\t12K skills.md";
-        await expect(page.locator(outputSelector)).exactTextInElement(
-          `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
         );
-        await expect(page.locator(promptSelector)).exactTextInElement(
-          defaultUserPrompt,
+        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+          DEFAULT_USER_PROMPT,
         );
-        await expect(page.locator(inputSelector)).exactTextInElement("");
+        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
         await checkForColouredSpans(page, {
           directory: 1,
@@ -328,8 +328,8 @@ test.describe("Ls", () => {
         const input = `ls -lh ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
         // Act
-        await page.locator(inputSelector).pressSequentially(input);
-        await page.locator(inputSelector).press("Enter");
+        await page.locator(INPUT_SELECTOR).pressSequentially(input);
+        await page.locator(INPUT_SELECTOR).press("Enter");
 
         // Assert
         const expected =
@@ -342,13 +342,13 @@ test.describe("Ls", () => {
           "\n-rw-rw-r-- 1 nathanwise nathanwise\t282K Jul 21 00:50 CV.pdf" +
           "\ndrwxrwxr-x 2 nathanwise nathanwise\t4K Aug 17 00:33 Education" +
           "\n-rw-rw-r-- 1 nathanwise nathanwise\t1K Jul 21 00:50 skills.md";
-        await expect(page.locator(outputSelector)).exactTextInElement(
-          `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+          `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
         );
-        await expect(page.locator(promptSelector)).exactTextInElement(
-          defaultUserPrompt,
+        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+          DEFAULT_USER_PROMPT,
         );
-        await expect(page.locator(inputSelector)).exactTextInElement("");
+        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
         await checkForColouredSpans(page, {
           directory: 1,
@@ -370,8 +370,8 @@ test.describe("Ls", () => {
       const input = `ls --block-size=2048 ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
       // Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
       const expected =
@@ -379,13 +379,13 @@ test.describe("Ls", () => {
         "\n/etc/hosts\t/home/nathanwise/Projects/this/.external" +
         "\n\n/home/nathanwise/Documents:" +
         "\nabout.txt\tCV.pdf\tEducation\tskills.md";
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       await checkForColouredSpans(page, {
         directory: 1,
@@ -503,17 +503,17 @@ test.describe("Ls", () => {
       const input = `ls ${flags.join(" ")} --block-size=${blockSize} ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
       // Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       await checkForColouredSpans(page, {
         directory: 1,
@@ -534,8 +534,8 @@ test.describe("Ls", () => {
       const input = `ls -l ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
       // Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
       const expected =
@@ -548,13 +548,13 @@ test.describe("Ls", () => {
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t288626 Jul 21 00:50 CV.pdf" +
         "\ndrwxrwxr-x 2 nathanwise nathanwise\t4096 Aug 17 00:33 Education" +
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t375 Jul 21 00:50 skills.md";
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       await checkForColouredSpans(page, {
         directory: 1,
@@ -571,8 +571,8 @@ test.describe("Ls", () => {
       const input = `ls -l ${existingDotFile} ${existingFile} ${existingDirectory} ${fakePath}`;
 
       // Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
       const expected =
@@ -585,13 +585,13 @@ test.describe("Ls", () => {
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t288626 Jul 21 00:50 CV.pdf" +
         "\ndrwxrwxr-x 2 nathanwise nathanwise\t4096 Aug 17 00:33 Education" +
         "\n-rw-rw-r-- 1 nathanwise nathanwise\t375 Jul 21 00:50 skills.md";
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       await checkForColouredSpans(page, {
         directory: 1,

--- a/test/e2e/spec/command/pwd.spec.ts
+++ b/test/e2e/spec/command/pwd.spec.ts
@@ -1,13 +1,10 @@
-import { expect, test } from "../../fixture";
+import { test } from "../../fixture";
+import { DEFAULT_CURRENT_WORKING_DIRECTORY } from "../../helper/constant/generic";
 import {
-  DEFAULT_CURRENT_WORKING_DIRECTORY,
-  DEFAULT_INITIAL_PROMPT,
-  DEFAULT_USER_PROMPT,
-  INPUT_SELECTOR,
-  OUTPUT_SELECTOR,
-  PROMPT_SELECTOR,
-} from "../../helper/constant/generic";
-import { getExpectedPrompt } from "../../helper/util/terminal_util";
+  assertExactTextInTerminal,
+  getExpectedPrompt,
+  runCommand,
+} from "../../helper/util/terminal_util";
 
 test.describe("Pwd", () => {
   test("should output the current working directory", async ({ page }) => {
@@ -15,17 +12,13 @@ test.describe("Pwd", () => {
     const input = "pwd";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${DEFAULT_CURRENT_WORKING_DIRECTORY}`,
+    await assertExactTextInTerminal(
+      page,
+      `${input}\n${DEFAULT_CURRENT_WORKING_DIRECTORY}`,
     );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("should output the changed current working directory when the current working directory is changed", async ({
@@ -34,18 +27,19 @@ test.describe("Pwd", () => {
     // Arrange
     const changedDirectory = "/usr/local/etc";
     const cdInput = `cd ${changedDirectory}`;
-    await page.locator(INPUT_SELECTOR).pressSequentially(cdInput);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, cdInput);
 
     const input = "pwd";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}\n${changedDirectory}`,
+    await assertExactTextInTerminal(
+      page,
+      `${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}\n${changedDirectory}`,
+      undefined,
+      getExpectedPrompt(changedDirectory),
     );
   });
 });

--- a/test/e2e/spec/command/pwd.spec.ts
+++ b/test/e2e/spec/command/pwd.spec.ts
@@ -1,7 +1,11 @@
 import { test } from "../../fixture";
-import { DEFAULT_CURRENT_WORKING_DIRECTORY } from "../../helper/constant/generic";
+import {
+  COMMAND_RAN_OUTPUT,
+  DEFAULT_CURRENT_WORKING_DIRECTORY,
+} from "../../helper/constant/generic";
 import {
   assertExactTextInTerminal,
+  assertOutputInTerminal,
   getExpectedPrompt,
   runCommand,
 } from "../../helper/util/terminal_util";
@@ -15,7 +19,7 @@ test.describe("Pwd", () => {
     await runCommand(page, input);
 
     // Assert
-    await assertExactTextInTerminal(
+    await assertOutputInTerminal(
       page,
       `${input}\n${DEFAULT_CURRENT_WORKING_DIRECTORY}`,
     );
@@ -37,8 +41,7 @@ test.describe("Pwd", () => {
     // Assert
     await assertExactTextInTerminal(
       page,
-      `${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}\n${changedDirectory}`,
-      undefined,
+      `${COMMAND_RAN_OUTPUT}${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}\n${changedDirectory}`,
       getExpectedPrompt(changedDirectory),
     );
   });

--- a/test/e2e/spec/command/pwd.spec.ts
+++ b/test/e2e/spec/command/pwd.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "../../fixture";
 import {
-  defaultCurrentWorkingDirectory,
-  defaultInitialPrompt,
-  defaultUserPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  DEFAULT_CURRENT_WORKING_DIRECTORY,
+  DEFAULT_INITIAL_PROMPT,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../../helper/constant/generic";
 import { getExpectedPrompt } from "../../helper/util/terminal_util";
 
@@ -15,17 +15,17 @@ test.describe("Pwd", () => {
     const input = "pwd";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${defaultCurrentWorkingDirectory}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${DEFAULT_CURRENT_WORKING_DIRECTORY}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
   });
 
   test("should output the changed current working directory when the current working directory is changed", async ({
@@ -34,18 +34,18 @@ test.describe("Pwd", () => {
     // Arrange
     const changedDirectory = "/usr/local/etc";
     const cdInput = `cd ${changedDirectory}`;
-    await page.locator(inputSelector).pressSequentially(cdInput);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(cdInput);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     const input = "pwd";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}\n${changedDirectory}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}\n${changedDirectory}`,
     );
   });
 });

--- a/test/e2e/spec/command/tree.spec.ts
+++ b/test/e2e/spec/command/tree.spec.ts
@@ -1,8 +1,12 @@
 import { test } from "../../fixture";
-import { INPUT_SELECTOR } from "../../helper/constant/generic";
+import {
+  COMMAND_RAN_OUTPUT,
+  INPUT_SELECTOR,
+} from "../../helper/constant/generic";
 import { checkForColouredSpans } from "../../helper/util/element_util.ts";
 import {
   assertExactTextInTerminal,
+  assertOutputInTerminal,
   getExpectedPrompt,
   runCommand,
 } from "../../helper/util/terminal_util.ts";
@@ -35,8 +39,7 @@ test.describe("Tree", () => {
       "1 directory, 3 files";
     await assertExactTextInTerminal(
       page,
-      `${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}${expected}`,
-      undefined,
+      `${COMMAND_RAN_OUTPUT}${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}${expected}`,
       getExpectedPrompt(changedDirectory),
     );
     await checkForColouredSpans(page, {
@@ -70,7 +73,7 @@ test.describe("Tree", () => {
       "└── skills.md\n" +
       "\n" +
       "2 directories, 6 files";
-    await assertExactTextInTerminal(page, `${input}${expected}`);
+    await assertOutputInTerminal(page, `${input}${expected}`);
     await checkForColouredSpans(page, {
       directory: 2,
       executables: 0,
@@ -92,7 +95,7 @@ test.describe("Tree", () => {
 
     // Assert
     const expected = "\n/boot\n" + "\n" + "0 directories, 0 files";
-    await assertExactTextInTerminal(page, `${input}${expected}`);
+    await assertOutputInTerminal(page, `${input}${expected}`);
     await checkForColouredSpans(page, {
       directory: 1,
       executables: 0,
@@ -132,7 +135,7 @@ test.describe("Tree", () => {
       await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
-      await assertExactTextInTerminal(page, `${input}${expected}`);
+      await assertOutputInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 0,
         executables: 0,
@@ -168,7 +171,7 @@ test.describe("Tree", () => {
         "└── .tmp\n" +
         "\n" +
         "2 directories, 7 files";
-      await assertExactTextInTerminal(page, `${input}${expected}`);
+      await assertOutputInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 2,
         executables: 0,
@@ -197,7 +200,7 @@ test.describe("Tree", () => {
         "└── Education\n" +
         "\n" +
         "2 directories";
-      await assertExactTextInTerminal(page, `${input}${expected}`);
+      await assertOutputInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 2,
         executables: 0,
@@ -244,7 +247,7 @@ test.describe("Tree", () => {
         "└── var\n" +
         "\n" +
         "17 directories, 0 files";
-      await assertExactTextInTerminal(page, `${input}${expected}`);
+      await assertOutputInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 17,
         executables: 0,

--- a/test/e2e/spec/command/tree.spec.ts
+++ b/test/e2e/spec/command/tree.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "../../fixture";
 import {
-  defaultInitialPrompt,
-  defaultUserPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  DEFAULT_INITIAL_PROMPT,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../../helper/constant/generic";
 import { checkForColouredSpans } from "../../helper/util/element_util.ts";
 import { getExpectedPrompt } from "../../helper/util/terminal_util.ts";
@@ -20,14 +20,14 @@ test.describe("Tree", () => {
     // Arrange
     const changedDirectory = "/home/nathanwise/Documents/Education";
     const cdInput = `cd ${changedDirectory}`;
-    await page.locator(inputSelector).pressSequentially(cdInput);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(cdInput);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     const input = "tree";
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expected =
@@ -37,13 +37,13 @@ test.describe("Tree", () => {
       "└── gcses.md\n" +
       "\n" +
       "1 directory, 3 files";
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}${expected}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}${expected}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
       getExpectedPrompt(changedDirectory),
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
     await checkForColouredSpans(page, {
       directory: 1,
@@ -62,8 +62,8 @@ test.describe("Tree", () => {
     const input = `tree ${existingDirectory}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expected =
@@ -77,13 +77,13 @@ test.describe("Tree", () => {
       "└── skills.md\n" +
       "\n" +
       "2 directories, 6 files";
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
     await checkForColouredSpans(page, {
       directory: 2,
@@ -102,18 +102,18 @@ test.describe("Tree", () => {
     const input = `tree ${existingEmptyDirectory}`;
 
     // Act
-    await page.locator(inputSelector).pressSequentially(input);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(input);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
     const expected = "\n/boot\n" + "\n" + "0 directories, 0 files";
-    await expect(page.locator(outputSelector)).exactTextInElement(
-      `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
     );
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement("");
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
     await checkForColouredSpans(page, {
       directory: 1,
@@ -150,17 +150,17 @@ test.describe("Tree", () => {
       const input = `tree ${arg}`;
 
       // Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       await checkForColouredSpans(page, {
         directory: 0,
@@ -181,8 +181,8 @@ test.describe("Tree", () => {
       const input = `tree ${existingDirectory} -a`;
 
       // Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
       const expected =
@@ -197,13 +197,13 @@ test.describe("Tree", () => {
         "└── .tmp\n" +
         "\n" +
         "2 directories, 7 files";
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       await checkForColouredSpans(page, {
         directory: 2,
@@ -224,8 +224,8 @@ test.describe("Tree", () => {
       const input = `tree ${existingDirectory} -d`;
 
       // Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
       const expected =
@@ -233,13 +233,13 @@ test.describe("Tree", () => {
         "└── Education\n" +
         "\n" +
         "2 directories";
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       await checkForColouredSpans(page, {
         directory: 2,
@@ -263,8 +263,8 @@ test.describe("Tree", () => {
       const input = "tree / -L 1";
 
       // Act
-      await page.locator(inputSelector).pressSequentially(input);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(input);
+      await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
       const expected =
@@ -287,13 +287,13 @@ test.describe("Tree", () => {
         "└── var\n" +
         "\n" +
         "17 directories, 0 files";
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        `${defaultInitialPrompt}\n${defaultUserPrompt}${input}${expected}`,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement("");
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 
       await checkForColouredSpans(page, {
         directory: 17,

--- a/test/e2e/spec/command/tree.spec.ts
+++ b/test/e2e/spec/command/tree.spec.ts
@@ -1,13 +1,11 @@
-import { expect, test } from "../../fixture";
-import {
-  DEFAULT_INITIAL_PROMPT,
-  DEFAULT_USER_PROMPT,
-  INPUT_SELECTOR,
-  OUTPUT_SELECTOR,
-  PROMPT_SELECTOR,
-} from "../../helper/constant/generic";
+import { test } from "../../fixture";
+import { INPUT_SELECTOR } from "../../helper/constant/generic";
 import { checkForColouredSpans } from "../../helper/util/element_util.ts";
-import { getExpectedPrompt } from "../../helper/util/terminal_util.ts";
+import {
+  assertExactTextInTerminal,
+  getExpectedPrompt,
+  runCommand,
+} from "../../helper/util/terminal_util.ts";
 
 test.describe("Tree", () => {
   const existingDirectory = "/home/nathanwise/Documents";
@@ -20,14 +18,12 @@ test.describe("Tree", () => {
     // Arrange
     const changedDirectory = "/home/nathanwise/Documents/Education";
     const cdInput = `cd ${changedDirectory}`;
-    await page.locator(INPUT_SELECTOR).pressSequentially(cdInput);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, cdInput);
 
     const input = "tree";
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
     const expected =
@@ -37,14 +33,12 @@ test.describe("Tree", () => {
       "└── gcses.md\n" +
       "\n" +
       "1 directory, 3 files";
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}${expected}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+    await assertExactTextInTerminal(
+      page,
+      `${cdInput}\n${getExpectedPrompt(changedDirectory)}${input}${expected}`,
+      undefined,
       getExpectedPrompt(changedDirectory),
     );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
     await checkForColouredSpans(page, {
       directory: 1,
       executables: 0,
@@ -62,8 +56,7 @@ test.describe("Tree", () => {
     const input = `tree ${existingDirectory}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
     const expected =
@@ -77,14 +70,7 @@ test.describe("Tree", () => {
       "└── skills.md\n" +
       "\n" +
       "2 directories, 6 files";
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+    await assertExactTextInTerminal(page, `${input}${expected}`);
     await checkForColouredSpans(page, {
       directory: 2,
       executables: 0,
@@ -102,19 +88,11 @@ test.describe("Tree", () => {
     const input = `tree ${existingEmptyDirectory}`;
 
     // Act
-    await page.locator(INPUT_SELECTOR).pressSequentially(input);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, input);
 
     // Assert
     const expected = "\n/boot\n" + "\n" + "0 directories, 0 files";
-    await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-      `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-    );
-    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-      DEFAULT_USER_PROMPT,
-    );
-    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+    await assertExactTextInTerminal(page, `${input}${expected}`);
     await checkForColouredSpans(page, {
       directory: 1,
       executables: 0,
@@ -154,14 +132,7 @@ test.describe("Tree", () => {
       await page.locator(INPUT_SELECTOR).press("Enter");
 
       // Assert
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+      await assertExactTextInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 0,
         executables: 0,
@@ -197,14 +168,7 @@ test.describe("Tree", () => {
         "└── .tmp\n" +
         "\n" +
         "2 directories, 7 files";
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+      await assertExactTextInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 2,
         executables: 0,
@@ -233,14 +197,7 @@ test.describe("Tree", () => {
         "└── Education\n" +
         "\n" +
         "2 directories";
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+      await assertExactTextInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 2,
         executables: 0,
@@ -287,14 +244,7 @@ test.describe("Tree", () => {
         "└── var\n" +
         "\n" +
         "17 directories, 0 files";
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-        `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}${expected}`,
-      );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
-
+      await assertExactTextInTerminal(page, `${input}${expected}`);
       await checkForColouredSpans(page, {
         directory: 17,
         executables: 0,

--- a/test/e2e/spec/command_history.spec.ts
+++ b/test/e2e/spec/command_history.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "../fixture";
 import {
-  inputSelector,
-  promptSelector,
-  defaultUserPrompt,
+  INPUT_SELECTOR,
+  PROMPT_SELECTOR,
+  DEFAULT_USER_PROMPT,
 } from "../helper/constant/generic";
 
 test.describe("with existing command history", () => {
@@ -17,8 +17,8 @@ test.describe("with existing command history", () => {
   test.beforeEach(async ({ page }) => {
     // Insert commands...
     for (const command of commands) {
-      await page.locator(inputSelector).pressSequentially(command);
-      await page.locator(inputSelector).press("Enter");
+      await page.locator(INPUT_SELECTOR).pressSequentially(command);
+      await page.locator(INPUT_SELECTOR).press("Enter");
     }
   });
 
@@ -26,14 +26,14 @@ test.describe("with existing command history", () => {
     page,
   }) => {
     // Arrange & Act
-    await page.locator(inputSelector).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
 
     // Assert
     // No check for output as commands significantly alter it.
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(
       commands[commands.length - 1],
     );
   });
@@ -42,15 +42,15 @@ test.describe("with existing command history", () => {
     page,
   }) => {
     // Arrange & Act
-    await page.locator(inputSelector).press("ArrowUp");
-    await page.locator(inputSelector).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
 
     // Assert
     // No check for output as commands significantly alter it.
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(
       commands[commands.length - 2],
     );
   });
@@ -59,16 +59,16 @@ test.describe("with existing command history", () => {
     page,
   }) => {
     // Arrange & Act
-    await page.locator(inputSelector).press("ArrowUp");
-    await page.locator(inputSelector).press("ArrowUp");
-    await page.locator(inputSelector).press("ArrowDown");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowDown");
 
     // Assert
     // No check for output as commands significantly alter it.
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(
       commands[commands.length - 1],
     );
   });
@@ -78,52 +78,52 @@ test.describe("with existing command history", () => {
   }) => {
     // Arrange
     const userInput = "some --fake=command example";
-    await page.locator(inputSelector).pressSequentially(userInput);
+    await page.locator(INPUT_SELECTOR).pressSequentially(userInput);
 
     // Act
-    await page.locator(inputSelector).press("ArrowUp");
-    await page.locator(inputSelector).press("ArrowDown");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowDown");
 
     // Assert
     // No check for output as commands significantly alter it.
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(userInput);
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(userInput);
   });
 
   test("pressing 'Down' from the user input does nothing", async ({ page }) => {
     // Arrange
     const userInput = "some --fake=command example";
-    await page.locator(inputSelector).pressSequentially(userInput);
+    await page.locator(INPUT_SELECTOR).pressSequentially(userInput);
 
     // Act
-    await page.locator(inputSelector).press("ArrowDown");
+    await page.locator(INPUT_SELECTOR).press("ArrowDown");
 
     // Assert
     // No check for output as commands significantly alter it.
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(userInput);
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(userInput);
   });
 
   test("typing data in a previously submitted command and returning to that retains the typed data", async ({
     page,
   }) => {
     // Arrange & Act
-    await page.locator(inputSelector).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
     const userInput = "some extra data";
-    await page.locator(inputSelector).pressSequentially(userInput);
-    await page.locator(inputSelector).press("ArrowDown");
-    await page.locator(inputSelector).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).pressSequentially(userInput);
+    await page.locator(INPUT_SELECTOR).press("ArrowDown");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
 
     // Assert
     // No check for output as commands significantly alter it.
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(
       commands[commands.length - 1] + userInput,
     );
   });
@@ -132,27 +132,27 @@ test.describe("with existing command history", () => {
     page,
   }) => {
     // Arrange & Act
-    await page.locator(inputSelector).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
     const userInput = "some extra data";
-    await page.locator(inputSelector).pressSequentially(userInput);
-    await page.locator(inputSelector).press("Enter");
+    await page.locator(INPUT_SELECTOR).pressSequentially(userInput);
+    await page.locator(INPUT_SELECTOR).press("Enter");
 
     // Assert
-    await page.locator(inputSelector).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
     // No check for output as commands significantly alter it.
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(
       commands[commands.length - 1] + userInput,
     );
 
-    await page.locator(inputSelector).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
     // No check for output as commands significantly alter it.
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(
       commands[commands.length - 1],
     );
   });
@@ -162,19 +162,19 @@ test.describe("with existing command history", () => {
       page,
     }) => {
       // Arrange
-      const content = await page.locator(inputSelector).textContent();
+      const content = await page.locator(INPUT_SELECTOR).textContent();
 
       // Act
       await page.keyboard.down("Shift");
-      await page.locator(inputSelector).press("ArrowUp");
+      await page.locator(INPUT_SELECTOR).press("ArrowUp");
       await page.keyboard.up("Shift");
 
       // Assert
       // No check for output as commands significantly alter it.
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement(content!);
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(content!);
     });
 
     test("pressing 'Shift+Down' moves the caret downwards and the current command does not get cycled", async ({
@@ -182,19 +182,19 @@ test.describe("with existing command history", () => {
     }) => {
       // Arrange
       await page.keyboard.press("ArrowUp"); // moving up to have history to move back down to
-      const content = await page.locator(inputSelector).textContent();
+      const content = await page.locator(INPUT_SELECTOR).textContent();
 
       // Act
       await page.keyboard.down("Shift");
-      await page.locator(inputSelector).press("ArrowDown");
+      await page.locator(INPUT_SELECTOR).press("ArrowDown");
       await page.keyboard.up("Shift");
 
       // Assert
       // No check for output as commands significantly alter it.
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement(content!);
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(content!);
     });
   });
 });
@@ -205,16 +205,16 @@ test.describe("without existing command history", () => {
   }) => {
     // Arrange
     const userInput = "some --fake=command example";
-    await page.locator(inputSelector).pressSequentially(userInput);
+    await page.locator(INPUT_SELECTOR).pressSequentially(userInput);
 
     // Act
-    await page.locator(inputSelector).press("ArrowUp");
+    await page.locator(INPUT_SELECTOR).press("ArrowUp");
 
     // Assert
     // No check for output as commands significantly alter it.
-    await expect(page.locator(promptSelector)).exactTextInElement(
-      defaultUserPrompt,
+    await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+      DEFAULT_USER_PROMPT,
     );
-    await expect(page.locator(inputSelector)).exactTextInElement(userInput);
+    await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(userInput);
   });
 });

--- a/test/e2e/spec/command_history.spec.ts
+++ b/test/e2e/spec/command_history.spec.ts
@@ -4,6 +4,7 @@ import {
   PROMPT_SELECTOR,
   DEFAULT_USER_PROMPT,
 } from "../helper/constant/generic";
+import { runCommand } from "../helper/util/terminal_util.ts";
 
 test.describe("with existing command history", () => {
   const commands: string[] = [
@@ -17,8 +18,7 @@ test.describe("with existing command history", () => {
   test.beforeEach(async ({ page }) => {
     // Insert commands...
     for (const command of commands) {
-      await page.locator(INPUT_SELECTOR).pressSequentially(command);
-      await page.locator(INPUT_SELECTOR).press("Enter");
+      await runCommand(page, command);
     }
   });
 
@@ -134,8 +134,7 @@ test.describe("with existing command history", () => {
     // Arrange & Act
     await page.locator(INPUT_SELECTOR).press("ArrowUp");
     const userInput = "some extra data";
-    await page.locator(INPUT_SELECTOR).pressSequentially(userInput);
-    await page.locator(INPUT_SELECTOR).press("Enter");
+    await runCommand(page, userInput);
 
     // Assert
     await page.locator(INPUT_SELECTOR).press("ArrowUp");

--- a/test/e2e/spec/command_parsing.spec.ts
+++ b/test/e2e/spec/command_parsing.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "../fixture";
 import { COMMAND_NOT_FOUND, INPUT_SELECTOR } from "../helper/constant/generic";
 import {
-  assertExactTextInTerminal,
+  assertOutputInTerminal,
   runCommand,
 } from "../helper/util/terminal_util.ts";
 
@@ -17,7 +17,7 @@ test("Typing a valid command and pressing Enter runs that command", async ({
   await runCommand(page, input);
 
   // Assert
-  await assertExactTextInTerminal(page, `${input}\n${commandArgs.join(" ")}`);
+  await assertOutputInTerminal(page, `${input}\n${commandArgs.join(" ")}`);
 });
 
 test("Typing an unknown command and pressing Enter returns that the command was not found", async ({
@@ -32,7 +32,7 @@ test("Typing an unknown command and pressing Enter returns that the command was 
   await runCommand(page, input);
 
   // Assert
-  await assertExactTextInTerminal(
+  await assertOutputInTerminal(
     page,
     `${input}\n${commandName}${COMMAND_NOT_FOUND}`,
   );
@@ -43,7 +43,7 @@ test("Typing no command and pressing Enter does nothing", async ({ page }) => {
   await runCommand(page, "");
 
   // Assert
-  await assertExactTextInTerminal(page, "");
+  await assertOutputInTerminal(page, "");
 });
 
 test("Pressing Enter should run a command & prevent a newline being inserted in the user input", async ({

--- a/test/e2e/spec/command_parsing.spec.ts
+++ b/test/e2e/spec/command_parsing.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "../fixture";
 import {
-  commandNotFound,
-  defaultInitialPrompt,
-  defaultUserPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  COMMAND_NOT_FOUND,
+  DEFAULT_INITIAL_PROMPT,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../helper/constant/generic";
 
 test("Typing a valid command and pressing Enter runs that command", async ({
@@ -17,17 +17,17 @@ test("Typing a valid command and pressing Enter runs that command", async ({
   const input = commandName + " " + commandArgs.join(" ");
 
   // Act
-  await page.locator(inputSelector).pressSequentially(input);
-  await page.locator(inputSelector).press("Enter");
+  await page.locator(INPUT_SELECTOR).pressSequentially(input);
+  await page.locator(INPUT_SELECTOR).press("Enter");
 
   // Assert
-  await expect(page.locator(outputSelector)).exactTextInElement(
-    `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${commandArgs.join(" ")}`,
+  await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+    `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${commandArgs.join(" ")}`,
   );
-  await expect(page.locator(promptSelector)).exactTextInElement(
-    defaultUserPrompt,
+  await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+    DEFAULT_USER_PROMPT,
   );
-  await expect(page.locator(inputSelector)).exactTextInElement("");
+  await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 });
 
 test("Typing an unknown command and pressing Enter returns that the command was not found", async ({
@@ -39,31 +39,31 @@ test("Typing an unknown command and pressing Enter returns that the command was 
   const input = commandName + " " + commandArgs.join(" ");
 
   // Act
-  await page.locator(inputSelector).pressSequentially(input);
-  await page.locator(inputSelector).press("Enter");
+  await page.locator(INPUT_SELECTOR).pressSequentially(input);
+  await page.locator(INPUT_SELECTOR).press("Enter");
 
   // Assert
-  await expect(page.locator(outputSelector)).exactTextInElement(
-    `${defaultInitialPrompt}\n${defaultUserPrompt}${input}\n${commandName}${commandNotFound}`,
+  await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+    `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${commandName}${COMMAND_NOT_FOUND}`,
   );
-  await expect(page.locator(promptSelector)).exactTextInElement(
-    defaultUserPrompt,
+  await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+    DEFAULT_USER_PROMPT,
   );
-  await expect(page.locator(inputSelector)).exactTextInElement("");
+  await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 });
 
 test("Typing no command and pressing Enter does nothing", async ({ page }) => {
   // Arrange & Act
-  await page.locator(inputSelector).press("Enter");
+  await page.locator(INPUT_SELECTOR).press("Enter");
 
   // Assert
-  await expect(page.locator(outputSelector)).exactTextInElement(
-    `${defaultInitialPrompt}\n${defaultUserPrompt}`,
+  await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+    `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}`,
   );
-  await expect(page.locator(promptSelector)).exactTextInElement(
-    defaultUserPrompt,
+  await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+    DEFAULT_USER_PROMPT,
   );
-  await expect(page.locator(inputSelector)).exactTextInElement("");
+  await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 });
 
 test("Pressing Enter should run a command & prevent a newline being inserted in the user input", async ({
@@ -75,9 +75,9 @@ test("Pressing Enter should run a command & prevent a newline being inserted in 
   const input = commandName + " " + commandArgs.join(" ");
 
   // Act
-  await page.locator(inputSelector).pressSequentially(input);
-  await page.locator(inputSelector).press("Enter");
+  await page.locator(INPUT_SELECTOR).pressSequentially(input);
+  await page.locator(INPUT_SELECTOR).press("Enter");
 
   // Assert
-  await expect(page.locator(inputSelector)).exactTextInElement("");
+  await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 });

--- a/test/e2e/spec/command_parsing.spec.ts
+++ b/test/e2e/spec/command_parsing.spec.ts
@@ -1,12 +1,9 @@
 import { expect, test } from "../fixture";
+import { COMMAND_NOT_FOUND, INPUT_SELECTOR } from "../helper/constant/generic";
 import {
-  COMMAND_NOT_FOUND,
-  DEFAULT_INITIAL_PROMPT,
-  DEFAULT_USER_PROMPT,
-  INPUT_SELECTOR,
-  OUTPUT_SELECTOR,
-  PROMPT_SELECTOR,
-} from "../helper/constant/generic";
+  assertExactTextInTerminal,
+  runCommand,
+} from "../helper/util/terminal_util.ts";
 
 test("Typing a valid command and pressing Enter runs that command", async ({
   page,
@@ -17,17 +14,10 @@ test("Typing a valid command and pressing Enter runs that command", async ({
   const input = commandName + " " + commandArgs.join(" ");
 
   // Act
-  await page.locator(INPUT_SELECTOR).pressSequentially(input);
-  await page.locator(INPUT_SELECTOR).press("Enter");
+  await runCommand(page, input);
 
   // Assert
-  await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-    `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${commandArgs.join(" ")}`,
-  );
-  await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-    DEFAULT_USER_PROMPT,
-  );
-  await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+  await assertExactTextInTerminal(page, `${input}\n${commandArgs.join(" ")}`);
 });
 
 test("Typing an unknown command and pressing Enter returns that the command was not found", async ({
@@ -39,31 +29,21 @@ test("Typing an unknown command and pressing Enter returns that the command was 
   const input = commandName + " " + commandArgs.join(" ");
 
   // Act
-  await page.locator(INPUT_SELECTOR).pressSequentially(input);
-  await page.locator(INPUT_SELECTOR).press("Enter");
+  await runCommand(page, input);
 
   // Assert
-  await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-    `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}${input}\n${commandName}${COMMAND_NOT_FOUND}`,
+  await assertExactTextInTerminal(
+    page,
+    `${input}\n${commandName}${COMMAND_NOT_FOUND}`,
   );
-  await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-    DEFAULT_USER_PROMPT,
-  );
-  await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
 });
 
 test("Typing no command and pressing Enter does nothing", async ({ page }) => {
   // Arrange & Act
-  await page.locator(INPUT_SELECTOR).press("Enter");
+  await runCommand(page, "");
 
   // Assert
-  await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
-    `${DEFAULT_INITIAL_PROMPT}\n${DEFAULT_USER_PROMPT}`,
-  );
-  await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-    DEFAULT_USER_PROMPT,
-  );
-  await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
+  await assertExactTextInTerminal(page, "");
 });
 
 test("Pressing Enter should run a command & prevent a newline being inserted in the user input", async ({
@@ -75,8 +55,7 @@ test("Pressing Enter should run a command & prevent a newline being inserted in 
   const input = commandName + " " + commandArgs.join(" ");
 
   // Act
-  await page.locator(INPUT_SELECTOR).pressSequentially(input);
-  await page.locator(INPUT_SELECTOR).press("Enter");
+  await runCommand(page, input);
 
   // Assert
   await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");

--- a/test/e2e/spec/jump_to_line_boundaries.spec.ts
+++ b/test/e2e/spec/jump_to_line_boundaries.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "../fixture";
-import { inputSelector } from "../helper/constant/generic";
+import { INPUT_SELECTOR } from "../helper/constant/generic";
 import { setCaretAtCharIndex } from "../helper/util/terminal_util";
 
-const defaultInput = "foo, bar ?<baz>gaz</baz> asd> // testing";
+const DEFAULT_INPUT = "foo, bar ?<baz>gaz</baz> asd> // testing";
 
 // Zero-width Space is present so all positions are +1
 [
@@ -28,24 +28,24 @@ const defaultInput = "foo, bar ?<baz>gaz</baz> asd> // testing";
     button: "End",
     withCtrl: false,
     expectedText: "the end of the user input",
-    expectedPosition: 1 + defaultInput.length,
+    expectedPosition: 1 + DEFAULT_INPUT.length,
   },
   {
     button: "e",
     withCtrl: true,
     expectedText: "the end of the user input",
-    expectedPosition: 1 + defaultInput.length,
+    expectedPosition: 1 + DEFAULT_INPUT.length,
   },
   {
     button: "E",
     withCtrl: true,
     expectedText: "the end of the user input",
-    expectedPosition: 1 + defaultInput.length,
+    expectedPosition: 1 + DEFAULT_INPUT.length,
   },
 ].forEach(({ button, withCtrl, expectedText, expectedPosition }) => {
   test.describe(`Pressing '${button}'`, () => {
     test.beforeEach(async ({ page }) => {
-      await page.locator(inputSelector).pressSequentially(defaultInput);
+      await page.locator(INPUT_SELECTOR).pressSequentially(DEFAULT_INPUT);
     });
 
     [
@@ -55,23 +55,23 @@ const defaultInput = "foo, bar ?<baz>gaz</baz> asd> // testing";
       },
       {
         type: "in the middle of the user input",
-        startIndex: Math.floor(defaultInput.length / 2),
+        startIndex: Math.floor(DEFAULT_INPUT.length / 2),
       },
       {
         type: "at the end of the user input",
-        startIndex: defaultInput.length,
+        startIndex: DEFAULT_INPUT.length,
       },
     ].forEach(({ type, startIndex }) => {
       test(`${type} moves the cursor to ${expectedText}`, async ({ page }) => {
         // Arrange
-        await setCaretAtCharIndex(page, inputSelector, startIndex);
+        await setCaretAtCharIndex(page, INPUT_SELECTOR, startIndex);
 
         // Act
         if (withCtrl) {
           await page.keyboard.down("Control");
         }
 
-        await page.locator(inputSelector).press(button);
+        await page.locator(INPUT_SELECTOR).press(button);
 
         if (withCtrl) {
           await page.keyboard.up("Control");

--- a/test/e2e/spec/user_input_actions.spec.ts
+++ b/test/e2e/spec/user_input_actions.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "../fixture";
 import {
-  defaultInitialPrompt,
-  defaultUserPrompt,
-  inputSelector,
-  outputSelector,
-  promptSelector,
+  DEFAULT_INITIAL_PROMPT,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+  OUTPUT_SELECTOR,
+  PROMPT_SELECTOR,
 } from "../helper/constant/generic";
 import {
   ALPHANUMERIC,
@@ -36,16 +36,16 @@ test.describe("Keyboard", () => {
         page,
       }) => {
         // Arrange & Act
-        await page.locator(inputSelector).pressSequentially(values);
+        await page.locator(INPUT_SELECTOR).pressSequentially(values);
 
         // Assert
-        await expect(page.locator(outputSelector)).exactTextInElement(
-          defaultInitialPrompt,
+        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+          DEFAULT_INITIAL_PROMPT,
         );
-        await expect(page.locator(promptSelector)).exactTextInElement(
-          defaultUserPrompt,
+        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+          DEFAULT_USER_PROMPT,
         );
-        await expect(page.locator(inputSelector)).exactTextInElement(values);
+        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(values);
       });
     });
 
@@ -59,19 +59,19 @@ test.describe("Keyboard", () => {
         // Act
         for (const char of NEWLINES) {
           newlineCounter++;
-          await page.locator(inputSelector).pressSequentially(char);
+          await page.locator(INPUT_SELECTOR).pressSequentially(char);
         }
 
         // Assert
-        const prompts = `\n${defaultUserPrompt}`.repeat(newlineCounter);
+        const prompts = `\n${DEFAULT_USER_PROMPT}`.repeat(newlineCounter);
 
-        await expect(page.locator(outputSelector)).exactTextInElement(
-          `${defaultInitialPrompt}${prompts}`,
+        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+          `${DEFAULT_INITIAL_PROMPT}${prompts}`,
         );
-        await expect(page.locator(promptSelector)).exactTextInElement(
-          defaultUserPrompt,
+        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+          DEFAULT_USER_PROMPT,
         );
-        await expect(page.locator(inputSelector)).exactTextInElement("");
+        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
       });
 
       test("With Shift can be typed in the user input", async ({ page }) => {
@@ -83,25 +83,25 @@ test.describe("Keyboard", () => {
           newlineCounter++;
 
           await page.keyboard.down("Shift");
-          await page.locator(inputSelector).pressSequentially(char);
+          await page.locator(INPUT_SELECTOR).pressSequentially(char);
           await page.keyboard.up("Shift");
         }
 
         // Assert
         const newlines = "\n".repeat(newlineCounter);
 
-        await expect(page.locator(outputSelector)).exactTextInElement(
-          defaultInitialPrompt,
+        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+          DEFAULT_INITIAL_PROMPT,
         );
-        await expect(page.locator(promptSelector)).exactTextInElement(
-          defaultUserPrompt,
+        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+          DEFAULT_USER_PROMPT,
         );
 
         // A Regular Character is required as most Browsers will obscure Newlines, causing this test to fail, even
         // though it actually passes.
         const character = "a";
-        await page.locator(inputSelector).pressSequentially(character);
-        await expect(page.locator(inputSelector)).exactTextInElement(
+        await page.locator(INPUT_SELECTOR).pressSequentially(character);
+        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(
           newlines + character,
         );
       });
@@ -120,16 +120,16 @@ test.describe("Keyboard", () => {
       browser,
     }) => {
       // Arrange & Act
-      await simulatePaste(page.locator(inputSelector), browser, values);
+      await simulatePaste(page.locator(INPUT_SELECTOR), browser, values);
 
       // Assert
-      await expect(page.locator(outputSelector)).exactTextInElement(
-        defaultInitialPrompt,
+      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        DEFAULT_INITIAL_PROMPT,
       );
-      await expect(page.locator(promptSelector)).exactTextInElement(
-        defaultUserPrompt,
+      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
+        DEFAULT_USER_PROMPT,
       );
-      await expect(page.locator(inputSelector)).exactTextInElement(values);
+      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(values);
     });
   });
 });

--- a/test/e2e/spec/user_input_actions.spec.ts
+++ b/test/e2e/spec/user_input_actions.spec.ts
@@ -14,6 +14,7 @@ import {
   WHITESPACE,
 } from "../helper/constant/charset";
 import { simulatePaste } from "../helper/util/clipboard_util";
+import { assertExactTextInTerminal } from "../helper/util/terminal_util.ts";
 
 test.describe("Keyboard", () => {
   /*
@@ -39,13 +40,13 @@ test.describe("Keyboard", () => {
         await page.locator(INPUT_SELECTOR).pressSequentially(values);
 
         // Assert
-        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        await assertExactTextInTerminal(
+          page,
+          "",
           DEFAULT_INITIAL_PROMPT,
+          undefined,
+          values,
         );
-        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-          DEFAULT_USER_PROMPT,
-        );
-        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(values);
       });
     });
 
@@ -64,14 +65,11 @@ test.describe("Keyboard", () => {
 
         // Assert
         const prompts = `\n${DEFAULT_USER_PROMPT}`.repeat(newlineCounter);
-
-        await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+        await assertExactTextInTerminal(
+          page,
+          "",
           `${DEFAULT_INITIAL_PROMPT}${prompts}`,
         );
-        await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-          DEFAULT_USER_PROMPT,
-        );
-        await expect(page.locator(INPUT_SELECTOR)).exactTextInElement("");
       });
 
       test("With Shift can be typed in the user input", async ({ page }) => {
@@ -123,13 +121,13 @@ test.describe("Keyboard", () => {
       await simulatePaste(page.locator(INPUT_SELECTOR), browser, values);
 
       // Assert
-      await expect(page.locator(OUTPUT_SELECTOR)).exactTextInElement(
+      await assertExactTextInTerminal(
+        page,
+        "",
         DEFAULT_INITIAL_PROMPT,
+        undefined,
+        values,
       );
-      await expect(page.locator(PROMPT_SELECTOR)).exactTextInElement(
-        DEFAULT_USER_PROMPT,
-      );
-      await expect(page.locator(INPUT_SELECTOR)).exactTextInElement(values);
     });
   });
 });

--- a/test/e2e/spec/user_input_actions.spec.ts
+++ b/test/e2e/spec/user_input_actions.spec.ts
@@ -42,7 +42,6 @@ test.describe("Keyboard", () => {
         // Assert
         await assertExactTextInTerminal(
           page,
-          "",
           DEFAULT_INITIAL_PROMPT,
           undefined,
           values,
@@ -67,7 +66,6 @@ test.describe("Keyboard", () => {
         const prompts = `\n${DEFAULT_USER_PROMPT}`.repeat(newlineCounter);
         await assertExactTextInTerminal(
           page,
-          "",
           `${DEFAULT_INITIAL_PROMPT}${prompts}`,
         );
       });
@@ -123,7 +121,6 @@ test.describe("Keyboard", () => {
       // Assert
       await assertExactTextInTerminal(
         page,
-        "",
         DEFAULT_INITIAL_PROMPT,
         undefined,
         values,

--- a/test/integration/helper/file_tree_mock.ts
+++ b/test/integration/helper/file_tree_mock.ts
@@ -1,7 +1,9 @@
 import { FileTreeNode } from "virtual:file-tree";
 
+/* eslint-disable @typescript-eslint/naming-convention */
 // noinspection JSUnusedGlobalSymbols
 export const fileTree: FileTreeNode[] = [
+  /* eslint-enable @typescript-eslint/naming-convention */
   {
     children: [
       {

--- a/test/integration/helper/setup.ts
+++ b/test/integration/helper/setup.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const { fs } = await import("memfs");
 
 vi.mock("node:fs", async () => {

--- a/test/integration/src/event/keydown.test.ts
+++ b/test/integration/src/event/keydown.test.ts
@@ -10,27 +10,27 @@ import * as aModule from "../../../../src/event/keydown_key/a";
 import * as eModule from "../../../../src/event/keydown_key/e";
 
 describe("Keydown Event", () => {
+  // Spy
+  const processA = vi.spyOn(aModule, "processA");
+  const processArrowDown = vi.spyOn(arrowDownModule, "processArrowDown");
+  const processArrowUp = vi.spyOn(arrowUpModule, "processArrowUp");
+  const processE = vi.spyOn(eModule, "processE");
+  const processEnd = vi.spyOn(endModule, "processEnd");
+  const processEnter = vi.spyOn(enterModule, "processEnter");
+  const processHome = vi.spyOn(homeModule, "processHome");
+  const processTab = vi.spyOn(tabModule, "processTab");
+
+  // Mock
+  vi.mock("../../../../src/event/keydown_key/a");
+  vi.mock("../../../../src/event/keydown_key/arrow_down");
+  vi.mock("../../../../src/event/keydown_key/arrow_up");
+  vi.mock("../../../../src/event/keydown_key/e");
+  vi.mock("../../../../src/event/keydown_key/end");
+  vi.mock("../../../../src/event/keydown_key/enter");
+  vi.mock("../../../../src/event/keydown_key/home");
+  vi.mock("../../../../src/event/keydown_key/tab");
+
   describe("keydown", () => {
-    // Spy
-    const processA = vi.spyOn(aModule, "processA");
-    const processArrowDown = vi.spyOn(arrowDownModule, "processArrowDown");
-    const processArrowUp = vi.spyOn(arrowUpModule, "processArrowUp");
-    const processE = vi.spyOn(eModule, "processE");
-    const processEnd = vi.spyOn(endModule, "processEnd");
-    const processEnter = vi.spyOn(enterModule, "processEnter");
-    const processHome = vi.spyOn(homeModule, "processHome");
-    const processTab = vi.spyOn(tabModule, "processTab");
-
-    // Mock
-    vi.mock("../../../../src/event/keydown_key/a");
-    vi.mock("../../../../src/event/keydown_key/arrow_down");
-    vi.mock("../../../../src/event/keydown_key/arrow_up");
-    vi.mock("../../../../src/event/keydown_key/e");
-    vi.mock("../../../../src/event/keydown_key/end");
-    vi.mock("../../../../src/event/keydown_key/enter");
-    vi.mock("../../../../src/event/keydown_key/home");
-    vi.mock("../../../../src/event/keydown_key/tab");
-
     // Other
     const functions = [
       processA,

--- a/test/integration/src/event/keydown_key/a.test.ts
+++ b/test/integration/src/event/keydown_key/a.test.ts
@@ -3,13 +3,13 @@ import { processA } from "../../../../../src/event/keydown_key/a";
 import * as homeModule from "../../../../../src/event/keydown_key/home";
 
 describe("A", () => {
+  // Spy
+  const processHome = vi.spyOn(homeModule, "processHome");
+
+  // Mock
+  vi.mock("../../../../../src/event/keydown_key/home");
+
   describe("processA", async () => {
-    // Spy
-    const processHome = vi.spyOn(homeModule, "processHome");
-
-    // Mock
-    vi.mock("../../../../../src/event/keydown_key/home");
-
     test("with 'Ctrl' moves the cursor to the start of the user input", async () => {
       // Arrange
       const event = new KeyboardEvent("keydown", { ctrlKey: true });

--- a/test/integration/src/event/keydown_key/e.test.ts
+++ b/test/integration/src/event/keydown_key/e.test.ts
@@ -1,15 +1,15 @@
-import { describe, test, expect, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import * as endModule from "../../../../../src/event/keydown_key/end";
 import { processE } from "../../../../../src/event/keydown_key/e";
 
 describe("E", () => {
+  // Spy
+  const processEnd = vi.spyOn(endModule, "processEnd");
+
+  // Mock
+  vi.mock("../../../../../src/event/keydown_key/end");
+
   describe("processE", () => {
-    // Spy
-    const processEnd = vi.spyOn(endModule, "processEnd");
-
-    // Mock
-    vi.mock("../../../../../src/event/keydown_key/end");
-
     test("with 'Ctrl' moves the cursor to the end of the user input", async () => {
       // Arrange
       const event = new KeyboardEvent("keydown", { ctrlKey: true });

--- a/test/integration/src/event/keydown_key/end.test.ts
+++ b/test/integration/src/event/keydown_key/end.test.ts
@@ -3,16 +3,15 @@ import TerminalUtil from "../../../../../src/util/terminal_util";
 import { processEnd } from "../../../../../src/event/keydown_key/end";
 
 describe("End", () => {
+  // Spy
+  const cursorToEnd = vi.spyOn(TerminalUtil, "cursorToEnd");
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+
+  const event = new KeyboardEvent("keydown");
+
   describe("processEnd", () => {
-    // Spy
-    const cursorToEnd = vi.spyOn(TerminalUtil, "cursorToEnd");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
-
-    // Other
-    const event = new KeyboardEvent("keydown");
-
     test("moves the cursor to the end of the user input", async () => {
       // Arrange & Act
       await processEnd(event);

--- a/test/integration/src/event/keydown_key/enter.test.ts
+++ b/test/integration/src/event/keydown_key/enter.test.ts
@@ -16,7 +16,7 @@ describe("Enter", () => {
   vi.mock("../../../../../src/util/command_util");
 
   beforeEach(() => {
-    CommandHistoryUtil.resetHistory();
+    CommandHistoryUtil._resetHistory();
   });
 
   describe("without 'Shift'", () => {
@@ -44,7 +44,7 @@ describe("Enter", () => {
       expect(addToHistory).toHaveBeenCalledWith(userInput);
       expect(addToHistory).toHaveBeenCalledWith("");
       expect(setHistoricCommand).not.toHaveBeenCalled();
-      expect(CommandHistoryUtil.getHistoryIndex()).toEqual(0);
+      expect(CommandHistoryUtil._getHistoryIndex()).toEqual(0);
       expect(CommandHistoryUtil.getHistory()).toStrictEqual(["", userInput]);
     });
 
@@ -64,7 +64,7 @@ describe("Enter", () => {
       // Assert
       expect(setHistoricCommand).toHaveBeenCalledExactlyOnceWith(userInput);
       expect(addToHistory).toHaveBeenCalledExactlyOnceWith("");
-      expect(CommandHistoryUtil.getHistoryIndex()).toEqual(0);
+      expect(CommandHistoryUtil._getHistoryIndex()).toEqual(0);
       expect(CommandHistoryUtil.getHistory()).toStrictEqual([
         "",
         userInput,
@@ -90,7 +90,7 @@ describe("Enter", () => {
       // Assert
       expect(setHistoricCommand).toHaveBeenCalledExactlyOnceWith(userInput);
       expect(addToHistory).toHaveBeenCalledExactlyOnceWith("");
-      expect(CommandHistoryUtil.getHistoryIndex()).toEqual(0);
+      expect(CommandHistoryUtil._getHistoryIndex()).toEqual(0);
       expect(CommandHistoryUtil.getHistory()).toStrictEqual([
         "",
         userInput,

--- a/test/integration/src/event/keydown_key/home.test.ts
+++ b/test/integration/src/event/keydown_key/home.test.ts
@@ -11,7 +11,6 @@ describe("Home", () => {
     // Mock
     vi.mock("../../../../../src/util/terminal_util");
 
-    // Other
     const event = new KeyboardEvent("keydown");
 
     test("moves the cursor to the start of the user input when no zero-width space is present", async () => {

--- a/test/integration/src/event/keydown_key/home.test.ts
+++ b/test/integration/src/event/keydown_key/home.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, vi } from "vitest";
 import { processHome } from "../../../../../src/event/keydown_key/home";
 import TerminalUtil from "../../../../../src/util/terminal_util";
-import { zeroWidthSpace } from "../../../../e2e/helper/constant/generic";
+import { ZERO_WIDTH_SPACE } from "../../../../e2e/helper/constant/generic";
 
 describe("Home", () => {
   describe("processHome", () => {
@@ -28,7 +28,7 @@ describe("Home", () => {
     test("moves the cursor to the first index when a zero-width space is present", async () => {
       // Arrange
       vi.mocked(TerminalUtil.getRawInput).mockReturnValue(
-        `${zeroWidthSpace}foo bar`,
+        `${ZERO_WIDTH_SPACE}foo bar`,
       );
 
       // Act

--- a/test/integration/src/event/keydown_key/tab.test.ts
+++ b/test/integration/src/event/keydown_key/tab.test.ts
@@ -6,26 +6,25 @@ import CommandUtil from "../../../../../src/util/command_util";
 import AutocompleteUtil from "../../../../../src/util/autocomplete_util";
 
 describe("Tab", () => {
+  // Spy
+  const getCommandScript = vi.spyOn(CommandUtil, "getCommandScript");
+  const getCommandSuggestions = vi.spyOn(
+    AutocompleteUtil,
+    "getCommandSuggestions",
+  );
+  const getFileAndDirectorySuggestions = vi.spyOn(
+    AutocompleteUtil,
+    "getFileAndDirectorySuggestions",
+  );
+  const autocomplete = vi.spyOn(AutocompleteUtil, "autocomplete");
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+  vi.mock("../../../../../src/util/meta_import_util");
+
+  const event = new KeyboardEvent("keydown");
+
   describe("processTab", () => {
-    // Spy
-    const getCommandScript = vi.spyOn(CommandUtil, "getCommandScript");
-    const getCommandSuggestions = vi.spyOn(
-      AutocompleteUtil,
-      "getCommandSuggestions",
-    );
-    const getFileAndDirectorySuggestions = vi.spyOn(
-      AutocompleteUtil,
-      "getFileAndDirectorySuggestions",
-    );
-    const autocomplete = vi.spyOn(AutocompleteUtil, "autocomplete");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
-    vi.mock("../../../../../src/util/meta_import_util");
-
-    // Other
-    const event = new KeyboardEvent("keydown");
-
     describe("Default autocompletion", () => {
       test("Autocompletes a command name when typing a command", async () => {
         // Arrange

--- a/test/integration/src/plugin/__snapshots__/vite_plugin_file_tree.test.ts.snap
+++ b/test/integration/src/plugin/__snapshots__/vite_plugin_file_tree.test.ts.snap
@@ -1,5 +1,341 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`VitePluginTree > walk > .gitkeep files are not included in the file tree 1`] = `
+[
+  {
+    "blocks": 1,
+    "children": [],
+    "group": "root",
+    "isDirectory": true,
+    "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+    "name": "foo",
+    "owner": "root",
+    "path": "",
+    "permissions": [
+      7,
+      5,
+      5,
+    ],
+    "size": 0,
+  },
+]
+`;
+
+exports[`VitePluginTree > walk > .meta files are not included in the file tree 1`] = `
+[
+  {
+    "blocks": 1,
+    "children": [],
+    "group": "root",
+    "isDirectory": true,
+    "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+    "name": "foo",
+    "owner": "root",
+    "path": "",
+    "permissions": [
+      7,
+      5,
+      5,
+    ],
+    "size": 0,
+  },
+]
+`;
+
+exports[`VitePluginTree > walk > should return a valid file tree with a default owner/root based on the home directory 1`] = `
+[
+  {
+    "blocks": 1,
+    "children": [
+      {
+        "blocks": 1,
+        "children": [],
+        "group": "root",
+        "isDirectory": true,
+        "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+        "name": "bar",
+        "owner": "root",
+        "path": "foo",
+        "permissions": [
+          7,
+          5,
+          5,
+        ],
+        "size": 0,
+      },
+    ],
+    "group": "root",
+    "isDirectory": true,
+    "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+    "name": "foo",
+    "owner": "root",
+    "path": "",
+    "permissions": [
+      7,
+      5,
+      5,
+    ],
+    "size": 0,
+  },
+  {
+    "blocks": 1,
+    "children": [
+      {
+        "blocks": 1,
+        "children": [
+          {
+            "blocks": 1,
+            "children": undefined,
+            "group": "bazzing.gaz",
+            "isDirectory": false,
+            "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+            "name": "bazzing.gaz",
+            "owner": "bazzing.gaz",
+            "path": "some/home",
+            "permissions": [
+              6,
+              6,
+              4,
+            ],
+            "size": 0,
+          },
+          {
+            "blocks": 1,
+            "children": [
+              {
+                "blocks": 1,
+                "children": undefined,
+                "group": "daz",
+                "isDirectory": false,
+                "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+                "name": "test",
+                "owner": "daz",
+                "path": "some/home/daz",
+                "permissions": [
+                  6,
+                  6,
+                  4,
+                ],
+                "size": 0,
+              },
+            ],
+            "group": "daz",
+            "isDirectory": true,
+            "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+            "name": "daz",
+            "owner": "daz",
+            "path": "some/home",
+            "permissions": [
+              7,
+              7,
+              5,
+            ],
+            "size": 0,
+          },
+          {
+            "blocks": 1,
+            "children": [
+              {
+                "blocks": 1,
+                "children": undefined,
+                "group": "gaz",
+                "isDirectory": false,
+                "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+                "name": "test",
+                "owner": "gaz",
+                "path": "some/home/gaz",
+                "permissions": [
+                  6,
+                  6,
+                  4,
+                ],
+                "size": 0,
+              },
+            ],
+            "group": "gaz",
+            "isDirectory": true,
+            "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+            "name": "gaz",
+            "owner": "gaz",
+            "path": "some/home",
+            "permissions": [
+              7,
+              7,
+              5,
+            ],
+            "size": 0,
+          },
+        ],
+        "group": "root",
+        "isDirectory": true,
+        "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+        "name": "home",
+        "owner": "root",
+        "path": "some",
+        "permissions": [
+          7,
+          5,
+          5,
+        ],
+        "size": 0,
+      },
+    ],
+    "group": "root",
+    "isDirectory": true,
+    "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+    "name": "some",
+    "owner": "root",
+    "path": "",
+    "permissions": [
+      7,
+      5,
+      5,
+    ],
+    "size": 0,
+  },
+]
+`;
+
+exports[`VitePluginTree > walk > should return a valid file tree with data from a .meta file 1`] = `
+[
+  {
+    "blocks": 1,
+    "children": [
+      {
+        "blocks": 1,
+        "children": undefined,
+        "group": "root",
+        "isDirectory": false,
+        "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+        "name": "baz.txt",
+        "owner": "some value",
+        "path": "bar",
+        "permissions": [
+          4,
+          5,
+          6,
+        ],
+        "size": 0,
+      },
+    ],
+    "group": "root",
+    "isDirectory": true,
+    "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+    "name": "bar",
+    "owner": "root",
+    "path": "",
+    "permissions": [
+      7,
+      5,
+      5,
+    ],
+    "size": 0,
+  },
+  {
+    "blocks": 1,
+    "children": [],
+    "group": "ing",
+    "isDirectory": true,
+    "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+    "name": "foo",
+    "owner": "test",
+    "path": "",
+    "permissions": [
+      1,
+      2,
+      3,
+    ],
+    "size": 0,
+  },
+]
+`;
+
+exports[`VitePluginTree > walk > should return the correct file tree 1`] = `
+[
+  {
+    "blocks": 1,
+    "children": undefined,
+    "group": "root",
+    "isDirectory": false,
+    "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+    "name": "bazzing.gaz",
+    "owner": "root",
+    "path": "",
+    "permissions": [
+      6,
+      6,
+      4,
+    ],
+    "size": 0,
+  },
+  {
+    "blocks": 1,
+    "children": [
+      {
+        "blocks": 1,
+        "children": undefined,
+        "group": "root",
+        "isDirectory": false,
+        "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+        "name": ".testing",
+        "owner": "root",
+        "path": "foo",
+        "permissions": [
+          6,
+          6,
+          4,
+        ],
+        "size": 0,
+      },
+      {
+        "blocks": 1,
+        "children": [],
+        "group": "root",
+        "isDirectory": true,
+        "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+        "name": "bar",
+        "owner": "root",
+        "path": "foo",
+        "permissions": [
+          7,
+          5,
+          5,
+        ],
+        "size": 0,
+      },
+      {
+        "blocks": 1,
+        "children": undefined,
+        "group": "root",
+        "isDirectory": false,
+        "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+        "name": "daz",
+        "owner": "root",
+        "path": "foo",
+        "permissions": [
+          6,
+          6,
+          4,
+        ],
+        "size": 0,
+      },
+    ],
+    "group": "root",
+    "isDirectory": true,
+    "lastModifiedTime": 2020-01-01T00:00:00.000Z,
+    "name": "foo",
+    "owner": "root",
+    "path": "",
+    "permissions": [
+      7,
+      5,
+      5,
+    ],
+    "size": 0,
+  },
+]
+`;
+
 exports[`walk > .gitkeep files are not included in the file tree 1`] = `
 [
   {

--- a/test/integration/src/plugin/vite_plugin_file_tree.test.ts
+++ b/test/integration/src/plugin/vite_plugin_file_tree.test.ts
@@ -13,122 +13,124 @@ function deepSortTree(nodes: FileTreeNode[]): FileTreeNode[] {
   }));
 }
 
-beforeEach(() => {
-  vol.reset();
-});
-
-describe("walk", () => {
-  test("should return the correct file tree", () => {
-    // Arrange
-    const testRootDir = "/walk-test-";
-
-    vol.fromJSON(
-      {
-        "foo/bar": null,
-        "bazzing.gaz": "",
-        "foo/.testing": "",
-        "foo/daz": "",
-      },
-      testRootDir,
-    );
-
-    // Act
-    const tree = walk(testRootDir);
-    fs.rmSync(testRootDir, { recursive: true, force: true });
-
-    // Assert
-    expect(deepSortTree(tree)).toMatchSnapshot();
+describe("VitePluginTree", () => {
+  beforeEach(() => {
+    vol.reset();
   });
 
-  test(".gitkeep files are not included in the file tree", () => {
-    // Arrange
-    const testRootDir = "/walk-test-";
+  describe("walk", () => {
+    test("should return the correct file tree", () => {
+      // Arrange
+      const testRootDir = "/walk-test-";
 
-    vol.fromJSON(
-      {
-        foo: null,
-        ".gitkeep": "",
-        "foo/.gitkeep": "",
-      },
-      testRootDir,
-    );
+      vol.fromJSON(
+        {
+          "foo/bar": null,
+          "bazzing.gaz": "",
+          "foo/.testing": "",
+          "foo/daz": "",
+        },
+        testRootDir,
+      );
 
-    // Act
-    const tree = walk(testRootDir);
-    fs.rmSync(testRootDir, { recursive: true, force: true });
+      // Act
+      const tree = walk(testRootDir);
+      fs.rmSync(testRootDir, { recursive: true, force: true });
 
-    // Assert
-    expect(deepSortTree(tree)).toMatchSnapshot();
-  });
+      // Assert
+      expect(deepSortTree(tree)).toMatchSnapshot();
+    });
 
-  test(".meta files are not included in the file tree", () => {
-    // Arrange
-    const testRootDir = "/walk-test-";
+    test(".gitkeep files are not included in the file tree", () => {
+      // Arrange
+      const testRootDir = "/walk-test-";
 
-    vol.fromJSON(
-      {
-        foo: null,
-        "foo.meta": "{}",
-      },
-      testRootDir,
-    );
+      vol.fromJSON(
+        {
+          foo: null,
+          ".gitkeep": "",
+          "foo/.gitkeep": "",
+        },
+        testRootDir,
+      );
 
-    // Act
-    const tree = walk(testRootDir);
-    fs.rmSync(testRootDir, { recursive: true, force: true });
+      // Act
+      const tree = walk(testRootDir);
+      fs.rmSync(testRootDir, { recursive: true, force: true });
 
-    // Assert
-    expect(deepSortTree(tree)).toMatchSnapshot();
-  });
+      // Assert
+      expect(deepSortTree(tree)).toMatchSnapshot();
+    });
 
-  // TODO: home dir test
-  test("should return a valid file tree with a default owner/root based on the home directory", () => {
-    // Arrange
-    const testRootDir = "/walk-test-";
+    test(".meta files are not included in the file tree", () => {
+      // Arrange
+      const testRootDir = "/walk-test-";
 
-    vol.fromJSON(
-      {
-        "foo/bar": null,
-        "some/home/bazzing.gaz": "",
-        "some/home/gaz/test": "",
-        "some/home/daz/test": "",
-      },
-      testRootDir,
-    );
+      vol.fromJSON(
+        {
+          foo: null,
+          "foo.meta": "{}",
+        },
+        testRootDir,
+      );
 
-    // Act
-    const tree = walk(testRootDir, "some/home");
-    fs.rmSync(testRootDir, { recursive: true, force: true });
+      // Act
+      const tree = walk(testRootDir);
+      fs.rmSync(testRootDir, { recursive: true, force: true });
 
-    // Assert
-    expect(deepSortTree(tree)).toMatchSnapshot();
-  });
+      // Assert
+      expect(deepSortTree(tree)).toMatchSnapshot();
+    });
 
-  test("should return a valid file tree with data from a .meta file", () => {
-    // Arrange
-    const testRootDir = "/walk-test-";
+    // TODO: home dir test
+    test("should return a valid file tree with a default owner/root based on the home directory", () => {
+      // Arrange
+      const testRootDir = "/walk-test-";
 
-    vol.fromJSON(
-      {
-        foo: null,
-        "foo.meta":
-          "{" +
-          "\"permissions\": [1, 2, 3], " +
-          "\"owner\": \"test\"," +
-          "\"group\": \"ing\"" +
-          "}",
-        "bar/baz.txt": "",
-        "bar/baz.txt.meta":
-          "{" + "\"permissions\": [4, 5, 6], " + "\"owner\": \"some value\"" + "}",
-      },
-      testRootDir,
-    );
+      vol.fromJSON(
+        {
+          "foo/bar": null,
+          "some/home/bazzing.gaz": "",
+          "some/home/gaz/test": "",
+          "some/home/daz/test": "",
+        },
+        testRootDir,
+      );
 
-    // Act
-    const tree = walk(testRootDir);
-    fs.rmSync(testRootDir, { recursive: true, force: true });
+      // Act
+      const tree = walk(testRootDir, "some/home");
+      fs.rmSync(testRootDir, { recursive: true, force: true });
 
-    // Assert
-    expect(deepSortTree(tree)).toMatchSnapshot();
+      // Assert
+      expect(deepSortTree(tree)).toMatchSnapshot();
+    });
+
+    test("should return a valid file tree with data from a .meta file", () => {
+      // Arrange
+      const testRootDir = "/walk-test-";
+
+      vol.fromJSON(
+        {
+          foo: null,
+          "foo.meta":
+            "{" +
+            "\"permissions\": [1, 2, 3], " +
+            "\"owner\": \"test\"," +
+            "\"group\": \"ing\"" +
+            "}",
+          "bar/baz.txt": "",
+          "bar/baz.txt.meta":
+            "{" + "\"permissions\": [4, 5, 6], " + "\"owner\": \"some value\"" + "}",
+        },
+        testRootDir,
+      );
+
+      // Act
+      const tree = walk(testRootDir);
+      fs.rmSync(testRootDir, { recursive: true, force: true });
+
+      // Assert
+      expect(deepSortTree(tree)).toMatchSnapshot();
+    });
   });
 });

--- a/test/integration/src/util/file_import_util.test.ts
+++ b/test/integration/src/util/file_import_util.test.ts
@@ -2,38 +2,40 @@ import { describe, expect, test } from "vitest";
 import FileImportUtil from "../../../../src/util/file_import_util";
 import path from "path";
 
-describe("readFile", () => {
-  test("should return null if file does not exist", async () => {
-    // Arrange
-    const input = "./" + path.join("bin", "fake_file.txt");
+describe("FileImportUtil", () => {
+  describe("readFile", () => {
+    test("should return null if file does not exist", async () => {
+      // Arrange
+      const input = "./" + path.join("bin", "fake_file.txt");
 
-    // Act
-    const result = await FileImportUtil.readFile(input);
+      // Act
+      const result = await FileImportUtil.readFile(input);
 
-    // Assert
-    expect(result).toBeNull();
-  });
+      // Assert
+      expect(result).toBeNull();
+    });
 
-  test("should return null for an existing .gitkeep file", async () => {
-    // Arrange
-    const input = "./" + path.join("media", ".gitkeep");
+    test("should return null for an existing .gitkeep file", async () => {
+      // Arrange
+      const input = "./" + path.join("media", ".gitkeep");
 
-    // Act
-    const result = await FileImportUtil.readFile(input);
+      // Act
+      const result = await FileImportUtil.readFile(input);
 
-    // Assert
-    expect(result).toBeNull();
-  });
+      // Assert
+      expect(result).toBeNull();
+    });
 
-  test("should return content for an existing file", async () => {
-    // Arrange
-    // Keep this up to date with "an" existing file path
-    const input = "./" + path.join("home", "nathanwise", "help.txt");
+    test("should return content for an existing file", async () => {
+      // Arrange
+      // Keep this up to date with "an" existing file path
+      const input = "./" + path.join("home", "nathanwise", "help.txt");
 
-    // Act
-    const result = await FileImportUtil.readFile(input);
+      // Act
+      const result = await FileImportUtil.readFile(input);
 
-    // Assert
-    expect(result).not.toBeNull();
+      // Assert
+      expect(result).not.toBeNull();
+    });
   });
 });

--- a/test/integration/src/util/meta_import_util.test.ts
+++ b/test/integration/src/util/meta_import_util.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import MetaImportUtil from "../../../../src/util/meta_import_util";
 
-describe("Meta Import Util", () => {
+describe("MetaImportUtil", () => {
   describe("getCommandScripts", () => {
     test("should return non-empty object of all files when script files exist", () => {
       // Arrange & Act

--- a/test/integration/src/util/terminal_util.test.ts
+++ b/test/integration/src/util/terminal_util.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../src/util/terminal_util";
-import { zeroWidthSpace } from "../../../e2e/helper/constant/generic";
+import { ZERO_WIDTH_SPACE } from "../../../e2e/helper/constant/generic";
 
 let inputElement: HTMLElement;
 let promptElement: HTMLElement;
@@ -82,7 +82,7 @@ describe("Input", () => {
 
       test(`should ${returnZeroWidth ? "" : "not "}return a zero-width space`, async () => {
         // Arrange
-        const insertedContent = zeroWidthSpace;
+        const insertedContent = ZERO_WIDTH_SPACE;
         inputElement.textContent = insertedContent;
 
         // Act
@@ -131,7 +131,7 @@ describe("Input", () => {
       TerminalUtil.setInput(text);
 
       // Assert
-      expect(inputElement.textContent).toBe(zeroWidthSpace);
+      expect(inputElement.textContent).toBe(ZERO_WIDTH_SPACE);
     });
   });
   describe("appendInput", () => {
@@ -151,7 +151,7 @@ describe("Input", () => {
     test("should set instead of append the input if the current input is a zero-width space", async () => {
       // Arrange
       const appendedText = "bar";
-      inputElement.textContent = zeroWidthSpace;
+      inputElement.textContent = ZERO_WIDTH_SPACE;
 
       // Act
       TerminalUtil.appendInput(appendedText);

--- a/test/integration/src/util/terminal_util.test.ts
+++ b/test/integration/src/util/terminal_util.test.ts
@@ -6,585 +6,591 @@ let inputElement: HTMLElement;
 let promptElement: HTMLElement;
 let outputElement: HTMLElement;
 
-beforeEach(() => {
-  // Mock terminal elements
-  document.body.innerHTML =
-    "<div id=\"input\" contenteditable=\"true\"></div>" +
-    "<div id=\"prompt\"></div>" +
-    "<div id=\"output\"></div>";
+describe("TerminalUtil", () => {
+  beforeEach(() => {
+    // Mock terminal elements
+    document.body.innerHTML =
+      "<div id=\"input\" contenteditable=\"true\"></div>" +
+      "<div id=\"prompt\"></div>" +
+      "<div id=\"output\"></div>";
 
-  inputElement = document.getElementById("input")!;
-  promptElement = document.getElementById("prompt")!;
-  outputElement = document.getElementById("output")!;
+    inputElement = document.getElementById("input")!;
+    promptElement = document.getElementById("prompt")!;
+    outputElement = document.getElementById("output")!;
 
-  Element.prototype.scrollIntoView = vi.fn();
-});
+    Element.prototype.scrollIntoView = vi.fn();
+  });
 
-describe("Input", () => {
-  describe("getInputElement", () => {
-    test("should return the terminal", async () => {
-      // Arrange & Act
-      const element = TerminalUtil.getInputElement();
+  describe("Input", () => {
+    describe("getInputElement", () => {
+      test("should return the terminal", async () => {
+        // Arrange & Act
+        const element = TerminalUtil.getInputElement();
 
-      // Assert
-      expect(element).not.toBeNull();
+        // Assert
+        expect(element).not.toBeNull();
+      });
+    });
+
+    [
+      { type: "getInput", returnZeroWidth: false },
+      { type: "getRawInput", returnZeroWidth: true },
+    ].forEach(({ type, returnZeroWidth }) => {
+      describe(type, () => {
+        function getInputType(type: string): string | undefined {
+          switch (type) {
+            case "getInput":
+              return TerminalUtil.getInput();
+            case "getRawInput":
+              return TerminalUtil.getRawInput();
+          }
+
+          return undefined;
+        }
+
+        test("should return the terminal content when the input element has content", async () => {
+          // Arrange
+          const insertedContent = "foo";
+          inputElement.textContent = insertedContent;
+
+          // Act
+          const content = getInputType(type);
+
+          // Assert
+          expect(content).toBe(insertedContent);
+        });
+
+        test("should return an empty string when the input element has no content", async () => {
+          // Arrange & Act
+          const content = getInputType(type);
+
+          // Assert
+          expect(content).not.toBeNull();
+          expect(content).toBe("");
+        });
+
+        test("should normalise spaces when they are present in the input element", async () => {
+          // Arrange
+          inputElement.innerHTML = "FOO&nbsp;BAR&nbsp;BAZ";
+
+          // Act
+          const content = getInputType(type);
+
+          // Assert
+          expect(content).not.toBeNull();
+          expect(content).toBe("FOO BAR BAZ");
+        });
+
+        test(`should ${returnZeroWidth ? "" : "not "}return a zero-width space`, async () => {
+          // Arrange
+          const insertedContent = ZERO_WIDTH_SPACE;
+          inputElement.textContent = insertedContent;
+
+          // Act
+          const content = getInputType(type);
+
+          // Assert
+          if (returnZeroWidth) {
+            expect(content).toBe(insertedContent);
+          } else {
+            expect(content).toBe("");
+          }
+        });
+      });
+    });
+
+    describe("setInput", () => {
+      test("should set text in the input element when the input element was previously empty", async () => {
+        // Arrange
+        const text = "foo";
+
+        // Act
+        TerminalUtil.setInput(text);
+
+        // Assert
+        expect(inputElement.textContent).toBe(text);
+      });
+
+      test("should set text in the input element when the input element had content", async () => {
+        // Arrange
+        const text = "foo";
+        inputElement.textContent = "bar";
+
+        // Act
+        TerminalUtil.setInput(text);
+
+        // Assert
+        expect(inputElement.textContent).toBe(text);
+      });
+
+      test("should set text in the input element as a zero-width space when an empty string is provided", async () => {
+        // Arrange
+        const text = "";
+        inputElement.textContent = "bar";
+
+        // Act
+        TerminalUtil.setInput(text);
+
+        // Assert
+        expect(inputElement.textContent).toBe(ZERO_WIDTH_SPACE);
+      });
+    });
+    describe("appendInput", () => {
+      test("should append text to the input element", async () => {
+        // Arrange
+        const existingText = "foo";
+        const appendedText = "bar";
+        inputElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendInput(appendedText);
+
+        // Assert
+        expect(inputElement.textContent).toBe(existingText + appendedText);
+      });
+
+      test("should set instead of append the input if the current input is a zero-width space", async () => {
+        // Arrange
+        const appendedText = "bar";
+        inputElement.textContent = ZERO_WIDTH_SPACE;
+
+        // Act
+        TerminalUtil.appendInput(appendedText);
+
+        // Assert
+        expect(inputElement.textContent).toBe(appendedText);
+      });
     });
   });
 
-  [
-    { type: "getInput", returnZeroWidth: false },
-    { type: "getRawInput", returnZeroWidth: true },
-  ].forEach(({ type, returnZeroWidth }) => {
-    describe(type, () => {
-      function getInputType(type: string): string | undefined {
-        switch (type) {
-          case "getInput":
-            return TerminalUtil.getInput();
-          case "getRawInput":
-            return TerminalUtil.getRawInput();
-        }
+  describe("Prompt", () => {
+    describe("getPromptElement", () => {
+      test("should return the prompt element", async () => {
+        // Arrange & Act
+        const element = TerminalUtil.getPromptElement();
 
-        return undefined;
-      }
-
-      test("should return the terminal content when the input element has content", async () => {
+        // Assert
+        expect(element).not.toBeNull();
+      });
+    });
+    describe("getPrompt", () => {
+      test("should return the prompt element content when the prompt element has content", async () => {
         // Arrange
         const insertedContent = "foo";
-        inputElement.textContent = insertedContent;
+        promptElement.textContent = insertedContent;
 
         // Act
-        const content = getInputType(type);
+        const content = TerminalUtil.getPrompt();
 
         // Assert
         expect(content).toBe(insertedContent);
       });
 
-      test("should return an empty string when the input element has no content", async () => {
+      test("should return an empty string when the prompt element has no content", async () => {
         // Arrange & Act
-        const content = getInputType(type);
+        const content = TerminalUtil.getPrompt();
 
         // Assert
         expect(content).not.toBeNull();
         expect(content).toBe("");
       });
 
-      test("should normalise spaces when they are present in the input element", async () => {
+      test("should normalise spaces when they are present in the prompt element", async () => {
         // Arrange
-        inputElement.innerHTML = "FOO&nbsp;BAR&nbsp;BAZ";
+        promptElement.innerHTML = "FOO&nbsp;BAR&nbsp;BAZ";
 
         // Act
-        const content = getInputType(type);
+        const content = TerminalUtil.getPrompt();
+
+        // Assert
+        expect(content).not.toBeNull();
+        expect(content).toBe("FOO BAR BAZ");
+      });
+    });
+    describe("setPrompt", () => {
+      test("should set text in the prompt element when the prompt element was previously empty", async () => {
+        // Arrange
+        const text = "foo";
+
+        // Act
+        TerminalUtil.setPrompt(text);
+
+        // Assert
+        expect(promptElement.textContent).toBe(text);
+      });
+
+      describe("setPromptPath", () => {
+        test("should set the prompt when provided a path", async () => {
+          // Arrange
+          const text = "/some/fake/path";
+
+          // Act
+          TerminalUtil.setPromptPath(text);
+
+          // Assert
+          expect(promptElement.textContent).toBe("C:\\some\\fake\\path>");
+        });
+
+        test("should set the prompt as a nearly empty prompt with an empty path", async () => {
+          // Arrange
+          const text = "";
+
+          // Act
+          TerminalUtil.setPromptPath(text);
+
+          // Assert
+          expect(promptElement.textContent).toBe("C:\\>");
+        });
+
+        test("should set the prompt as a nearly empty prompt with a root path", async () => {
+          // Arrange
+          const text = "";
+
+          // Act
+          TerminalUtil.setPromptPath(text);
+
+          // Assert
+          expect(promptElement.textContent).toBe("C:\\>");
+        });
+      });
+
+      test("should set text in the prompt element when the prompt element had content", async () => {
+        // Arrange
+        const text = "foo";
+        promptElement.textContent = "bar";
+
+        // Act
+        TerminalUtil.setPrompt(text);
+
+        // Assert
+        expect(promptElement.textContent).toBe(text);
+      });
+    });
+    describe("appendPrompt", () => {
+      test("should append text to the prompt element", async () => {
+        // Arrange
+        const existingText = "foo";
+        const appendedText = "bar";
+        promptElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendPrompt(appendedText);
+
+        // Assert
+        expect(promptElement.textContent).toBe(existingText + appendedText);
+      });
+    });
+  });
+
+  describe("Output", () => {
+    describe("getOutputElement", () => {
+      test("should return the output element", async () => {
+        // Arrange & Act
+        const element = TerminalUtil.getOutputElement();
+
+        // Assert
+        expect(element).not.toBeNull();
+      });
+    });
+    describe("getRawOutput", () => {
+      test("should return the output element content when the output element has content", async () => {
+        // Arrange
+        const insertedContent = "foo";
+        outputElement.textContent = insertedContent;
+
+        // Act
+        const content = TerminalUtil.getRawOutput();
+
+        // Assert
+        expect(content).toBe(insertedContent);
+      });
+
+      test("should return an empty string when the output element has no content", async () => {
+        // Arrange & Act
+        const content = TerminalUtil.getRawOutput();
+
+        // Assert
+        expect(content).not.toBeNull();
+        expect(content).toBe("");
+      });
+
+      test("should normalise spaces when they are present in the output element", async () => {
+        // Arrange
+        outputElement.innerHTML = "FOO&nbsp;BAR&nbsp;BAZ";
+
+        // Act
+        const content = TerminalUtil.getRawOutput();
 
         // Assert
         expect(content).not.toBeNull();
         expect(content).toBe("FOO BAR BAZ");
       });
 
-      test(`should ${returnZeroWidth ? "" : "not "}return a zero-width space`, async () => {
+      test("should return non-escaped HTML specific characters when a nested HTML element exists within the output element", async () => {
         // Arrange
-        const insertedContent = ZERO_WIDTH_SPACE;
-        inputElement.textContent = insertedContent;
+        outputElement.innerHTML =
+          "TEST<a href='https://nathanwise.tech'>&gt;asdas das&lt;</a>ING";
 
         // Act
-        const content = getInputType(type);
+        const content = TerminalUtil.getRawOutput();
 
         // Assert
-        if (returnZeroWidth) {
-          expect(content).toBe(insertedContent);
-        } else {
-          expect(content).toBe("");
-        }
+        expect(content).not.toBeNull();
+        expect(content).toBe(
+          "TEST<a href=\"https://nathanwise.tech\">&gt;asdas das&lt;</a>ING",
+        );
+      });
+    });
+    describe("getOutput", () => {
+      test("should return the output element content when the output element has content", async () => {
+        // Arrange
+        const insertedContent = "foo";
+        outputElement.textContent = insertedContent;
+
+        // Act
+        const content = TerminalUtil.getOutput();
+
+        // Assert
+        expect(content).toBe(insertedContent);
+      });
+
+      test("should return an empty string when the output element has no content", async () => {
+        // Arrange & Act
+        const content = TerminalUtil.getOutput();
+
+        // Assert
+        expect(content).not.toBeNull();
+        expect(content).toBe("");
+      });
+
+      test("should normalise spaces when they are present in the output element", async () => {
+        // Arrange
+        outputElement.innerHTML = "FOO&nbsp;BAR&nbsp;BAZ";
+
+        // Act
+        const content = TerminalUtil.getOutput();
+
+        // Assert
+        expect(content).not.toBeNull();
+        expect(content).toBe("FOO BAR BAZ");
+      });
+
+      test("should return non-escaped HTML specific characters when a nested HTML element exists within the output element", async () => {
+        // Arrange
+        outputElement.innerHTML =
+          "TEST<a href='https://nathanwise.tech'>&gt;asdas das&lt;</a>ING";
+
+        // Act
+        const content = TerminalUtil.getOutput();
+
+        // Assert
+        expect(content).not.toBeNull();
+        expect(content).toBe(
+          "TEST<a href=\"https://nathanwise.tech\">>asdas das<</a>ING",
+        );
+      });
+    });
+    describe("setOutput", () => {
+      test("should set text in the output element when the output element was previously empty", async () => {
+        // Arrange
+        const text = "foo";
+
+        // Act
+        TerminalUtil.setOutput(text);
+
+        // Assert
+        expect(outputElement.textContent).toBe(text);
+      });
+
+      test("should set text in the output element when the output element had content", async () => {
+        // Arrange
+        const text = "foo";
+        outputElement.textContent = "bar";
+
+        // Act
+        TerminalUtil.setOutput(text);
+
+        // Assert
+        expect(outputElement.textContent).toBe(text);
+      });
+
+      test("should escape HTML specific characters when setting text in the output element", async () => {
+        const text = "TEST<a href='https://nathanwise.tech'>example</a>ING";
+
+        // Act
+        TerminalUtil.setOutput(text);
+
+        // Assert
+        expect(outputElement.textContent).toBe(text);
+
+        const escapedText =
+          "TEST&lt;a href='https://nathanwise.tech'&gt;example&lt;/a&gt;ING";
+        expect(outputElement.innerHTML).toBe(escapedText);
+      });
+    });
+    describe("setRawOutput", () => {
+      test("should set text in the output element when the output element was previously empty", async () => {
+        // Arrange
+        const text = "foo";
+
+        // Act
+        TerminalUtil.setRawOutput(text);
+
+        // Assert
+        expect(outputElement.textContent).toBe(text);
+      });
+
+      test("should set text in the output element when the output element had content", async () => {
+        // Arrange
+        const text = "foo";
+        outputElement.textContent = "bar";
+
+        // Act
+        TerminalUtil.setRawOutput(text);
+
+        // Assert
+        expect(outputElement.textContent).toBe(text);
+      });
+
+      test("should escape HTML specific characters when setting text in the output element", async () => {
+        const text = "TEST<a href='https://nathanwise.tech'>example</a>ING";
+
+        // Act
+        TerminalUtil.setRawOutput(text);
+
+        // Assert
+        const onlyText = "TESTexampleING";
+        expect(outputElement.textContent).toBe(onlyText);
+        expect(outputElement.innerHTML).toBe(text.replace(/'/g, "\""));
+      });
+    });
+    describe("appendOutput", () => {
+      test("should append text to the output element", async () => {
+        // Arrange
+        const existingText = "foo";
+        const appendedText = "bar";
+        outputElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendOutput(appendedText);
+
+        // Assert
+        expect(outputElement.textContent).toBe(existingText + appendedText);
+      });
+
+      test("should append a newline if text exists in the output", () => {
+        // Arrange
+        const existingText = "foo";
+        const appendedText = "bar";
+        outputElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendOutput(appendedText, true);
+
+        // Assert
+        expect(outputElement.textContent).toBe(
+          `${existingText}\n${appendedText}`,
+        );
+      });
+
+      test("should not append a newline if text does not exist in the output", () => {
+        // Arrange
+        const existingText = "";
+        const appendedText = "bar";
+        outputElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendOutput(appendedText, true);
+
+        // Assert
+        expect(outputElement.textContent).toBe(
+          `${existingText}${appendedText}`,
+        );
+      });
+
+      test("should escape HTML specific characters when appending text to the output element", async () => {
+        // Arrange
+        const existingText = "foo";
+        const appendedText =
+          "TEST<a href='https://nathanwise.tech'>example</a>ING";
+        outputElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendOutput(appendedText);
+
+        // Assert
+        expect(outputElement.textContent).toBe(existingText + appendedText);
+
+        const escapedText =
+          "TEST&lt;a href='https://nathanwise.tech'&gt;example&lt;/a&gt;ING";
+        expect(outputElement.innerHTML).toBe(existingText + escapedText);
+      });
+    });
+    describe("appendRawOutput", () => {
+      test("should append text to the output element", async () => {
+        // Arrange
+        const existingText = "foo";
+        const appendedText = "bar";
+        outputElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendRawOutput(appendedText);
+
+        // Assert
+        expect(outputElement.textContent).toBe(existingText + appendedText);
+      });
+
+      test("should append a newline if text exists in the output", () => {
+        // Arrange
+        const existingText = "foo";
+        const appendedText = "bar";
+        outputElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendRawOutput(appendedText, true);
+
+        // Assert
+        expect(outputElement.textContent).toBe(
+          `${existingText}\n${appendedText}`,
+        );
+      });
+
+      test("should not append a newline if text does not exist in the output", () => {
+        // Arrange
+        const existingText = "";
+        const appendedText = "bar";
+        outputElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendRawOutput(appendedText, true);
+
+        // Assert
+        expect(outputElement.textContent).toBe(
+          `${existingText}${appendedText}`,
+        );
+      });
+
+      test("should escape HTML specific characters when appending text to the output element", async () => {
+        // Arrange
+        const existingText = "foo";
+        const appendedText =
+          "TEST<a href='https://nathanwise.tech'>example</a>ING";
+        outputElement.textContent = existingText;
+
+        // Act
+        TerminalUtil.appendRawOutput(appendedText);
+
+        // Assert
+        const onlyText = "TESTexampleING";
+        expect(outputElement.textContent).toBe(existingText + onlyText);
+
+        expect(outputElement.innerHTML).toBe(
+          existingText + appendedText.replace(/'/g, "\""),
+        );
       });
     });
   });
 
-  describe("setInput", () => {
-    test("should set text in the input element when the input element was previously empty", async () => {
-      // Arrange
-      const text = "foo";
-
-      // Act
-      TerminalUtil.setInput(text);
-
-      // Assert
-      expect(inputElement.textContent).toBe(text);
-    });
-
-    test("should set text in the input element when the input element had content", async () => {
-      // Arrange
-      const text = "foo";
-      inputElement.textContent = "bar";
-
-      // Act
-      TerminalUtil.setInput(text);
-
-      // Assert
-      expect(inputElement.textContent).toBe(text);
-    });
-
-    test("should set text in the input element as a zero-width space when an empty string is provided", async () => {
-      // Arrange
-      const text = "";
-      inputElement.textContent = "bar";
-
-      // Act
-      TerminalUtil.setInput(text);
-
-      // Assert
-      expect(inputElement.textContent).toBe(ZERO_WIDTH_SPACE);
-    });
-  });
-  describe("appendInput", () => {
-    test("should append text to the input element", async () => {
-      // Arrange
-      const existingText = "foo";
-      const appendedText = "bar";
-      inputElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendInput(appendedText);
-
-      // Assert
-      expect(inputElement.textContent).toBe(existingText + appendedText);
-    });
-
-    test("should set instead of append the input if the current input is a zero-width space", async () => {
-      // Arrange
-      const appendedText = "bar";
-      inputElement.textContent = ZERO_WIDTH_SPACE;
-
-      // Act
-      TerminalUtil.appendInput(appendedText);
-
-      // Assert
-      expect(inputElement.textContent).toBe(appendedText);
-    });
-  });
+  // Can't test "cursorToEnd" effectively with JSDom - rely on E2E to test this
+  // Can't test "cursorToIndex" effectively with JSDom - rely on E2E to test this
 });
-
-describe("Prompt", () => {
-  describe("getPromptElement", () => {
-    test("should return the prompt element", async () => {
-      // Arrange & Act
-      const element = TerminalUtil.getPromptElement();
-
-      // Assert
-      expect(element).not.toBeNull();
-    });
-  });
-  describe("getPrompt", () => {
-    test("should return the prompt element content when the prompt element has content", async () => {
-      // Arrange
-      const insertedContent = "foo";
-      promptElement.textContent = insertedContent;
-
-      // Act
-      const content = TerminalUtil.getPrompt();
-
-      // Assert
-      expect(content).toBe(insertedContent);
-    });
-
-    test("should return an empty string when the prompt element has no content", async () => {
-      // Arrange & Act
-      const content = TerminalUtil.getPrompt();
-
-      // Assert
-      expect(content).not.toBeNull();
-      expect(content).toBe("");
-    });
-
-    test("should normalise spaces when they are present in the prompt element", async () => {
-      // Arrange
-      promptElement.innerHTML = "FOO&nbsp;BAR&nbsp;BAZ";
-
-      // Act
-      const content = TerminalUtil.getPrompt();
-
-      // Assert
-      expect(content).not.toBeNull();
-      expect(content).toBe("FOO BAR BAZ");
-    });
-  });
-  describe("setPrompt", () => {
-    test("should set text in the prompt element when the prompt element was previously empty", async () => {
-      // Arrange
-      const text = "foo";
-
-      // Act
-      TerminalUtil.setPrompt(text);
-
-      // Assert
-      expect(promptElement.textContent).toBe(text);
-    });
-
-    describe("setPromptPath", () => {
-      test("should set the prompt when provided a path", async () => {
-        // Arrange
-        const text = "/some/fake/path";
-
-        // Act
-        TerminalUtil.setPromptPath(text);
-
-        // Assert
-        expect(promptElement.textContent).toBe("C:\\some\\fake\\path>");
-      });
-
-      test("should set the prompt as a nearly empty prompt with an empty path", async () => {
-        // Arrange
-        const text = "";
-
-        // Act
-        TerminalUtil.setPromptPath(text);
-
-        // Assert
-        expect(promptElement.textContent).toBe("C:\\>");
-      });
-
-      test("should set the prompt as a nearly empty prompt with a root path", async () => {
-        // Arrange
-        const text = "";
-
-        // Act
-        TerminalUtil.setPromptPath(text);
-
-        // Assert
-        expect(promptElement.textContent).toBe("C:\\>");
-      });
-    });
-
-    test("should set text in the prompt element when the prompt element had content", async () => {
-      // Arrange
-      const text = "foo";
-      promptElement.textContent = "bar";
-
-      // Act
-      TerminalUtil.setPrompt(text);
-
-      // Assert
-      expect(promptElement.textContent).toBe(text);
-    });
-  });
-  describe("appendPrompt", () => {
-    test("should append text to the prompt element", async () => {
-      // Arrange
-      const existingText = "foo";
-      const appendedText = "bar";
-      promptElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendPrompt(appendedText);
-
-      // Assert
-      expect(promptElement.textContent).toBe(existingText + appendedText);
-    });
-  });
-});
-
-describe("Output", () => {
-  describe("getOutputElement", () => {
-    test("should return the output element", async () => {
-      // Arrange & Act
-      const element = TerminalUtil.getOutputElement();
-
-      // Assert
-      expect(element).not.toBeNull();
-    });
-  });
-  describe("getRawOutput", () => {
-    test("should return the output element content when the output element has content", async () => {
-      // Arrange
-      const insertedContent = "foo";
-      outputElement.textContent = insertedContent;
-
-      // Act
-      const content = TerminalUtil.getRawOutput();
-
-      // Assert
-      expect(content).toBe(insertedContent);
-    });
-
-    test("should return an empty string when the output element has no content", async () => {
-      // Arrange & Act
-      const content = TerminalUtil.getRawOutput();
-
-      // Assert
-      expect(content).not.toBeNull();
-      expect(content).toBe("");
-    });
-
-    test("should normalise spaces when they are present in the output element", async () => {
-      // Arrange
-      outputElement.innerHTML = "FOO&nbsp;BAR&nbsp;BAZ";
-
-      // Act
-      const content = TerminalUtil.getRawOutput();
-
-      // Assert
-      expect(content).not.toBeNull();
-      expect(content).toBe("FOO BAR BAZ");
-    });
-
-    test("should return non-escaped HTML specific characters when a nested HTML element exists within the output element", async () => {
-      // Arrange
-      outputElement.innerHTML =
-        "TEST<a href='https://nathanwise.tech'>&gt;asdas das&lt;</a>ING";
-
-      // Act
-      const content = TerminalUtil.getRawOutput();
-
-      // Assert
-      expect(content).not.toBeNull();
-      expect(content).toBe(
-        "TEST<a href=\"https://nathanwise.tech\">&gt;asdas das&lt;</a>ING",
-      );
-    });
-  });
-  describe("getOutput", () => {
-    test("should return the output element content when the output element has content", async () => {
-      // Arrange
-      const insertedContent = "foo";
-      outputElement.textContent = insertedContent;
-
-      // Act
-      const content = TerminalUtil.getOutput();
-
-      // Assert
-      expect(content).toBe(insertedContent);
-    });
-
-    test("should return an empty string when the output element has no content", async () => {
-      // Arrange & Act
-      const content = TerminalUtil.getOutput();
-
-      // Assert
-      expect(content).not.toBeNull();
-      expect(content).toBe("");
-    });
-
-    test("should normalise spaces when they are present in the output element", async () => {
-      // Arrange
-      outputElement.innerHTML = "FOO&nbsp;BAR&nbsp;BAZ";
-
-      // Act
-      const content = TerminalUtil.getOutput();
-
-      // Assert
-      expect(content).not.toBeNull();
-      expect(content).toBe("FOO BAR BAZ");
-    });
-
-    test("should return non-escaped HTML specific characters when a nested HTML element exists within the output element", async () => {
-      // Arrange
-      outputElement.innerHTML =
-        "TEST<a href='https://nathanwise.tech'>&gt;asdas das&lt;</a>ING";
-
-      // Act
-      const content = TerminalUtil.getOutput();
-
-      // Assert
-      expect(content).not.toBeNull();
-      expect(content).toBe(
-        "TEST<a href=\"https://nathanwise.tech\">>asdas das<</a>ING",
-      );
-    });
-  });
-  describe("setOutput", () => {
-    test("should set text in the output element when the output element was previously empty", async () => {
-      // Arrange
-      const text = "foo";
-
-      // Act
-      TerminalUtil.setOutput(text);
-
-      // Assert
-      expect(outputElement.textContent).toBe(text);
-    });
-
-    test("should set text in the output element when the output element had content", async () => {
-      // Arrange
-      const text = "foo";
-      outputElement.textContent = "bar";
-
-      // Act
-      TerminalUtil.setOutput(text);
-
-      // Assert
-      expect(outputElement.textContent).toBe(text);
-    });
-
-    test("should escape HTML specific characters when setting text in the output element", async () => {
-      const text = "TEST<a href='https://nathanwise.tech'>example</a>ING";
-
-      // Act
-      TerminalUtil.setOutput(text);
-
-      // Assert
-      expect(outputElement.textContent).toBe(text);
-
-      const escapedText =
-        "TEST&lt;a href='https://nathanwise.tech'&gt;example&lt;/a&gt;ING";
-      expect(outputElement.innerHTML).toBe(escapedText);
-    });
-  });
-  describe("setRawOutput", () => {
-    test("should set text in the output element when the output element was previously empty", async () => {
-      // Arrange
-      const text = "foo";
-
-      // Act
-      TerminalUtil.setRawOutput(text);
-
-      // Assert
-      expect(outputElement.textContent).toBe(text);
-    });
-
-    test("should set text in the output element when the output element had content", async () => {
-      // Arrange
-      const text = "foo";
-      outputElement.textContent = "bar";
-
-      // Act
-      TerminalUtil.setRawOutput(text);
-
-      // Assert
-      expect(outputElement.textContent).toBe(text);
-    });
-
-    test("should escape HTML specific characters when setting text in the output element", async () => {
-      const text = "TEST<a href='https://nathanwise.tech'>example</a>ING";
-
-      // Act
-      TerminalUtil.setRawOutput(text);
-
-      // Assert
-      const onlyText = "TESTexampleING";
-      expect(outputElement.textContent).toBe(onlyText);
-      expect(outputElement.innerHTML).toBe(text.replace(/'/g, "\""));
-    });
-  });
-  describe("appendOutput", () => {
-    test("should append text to the output element", async () => {
-      // Arrange
-      const existingText = "foo";
-      const appendedText = "bar";
-      outputElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendOutput(appendedText);
-
-      // Assert
-      expect(outputElement.textContent).toBe(existingText + appendedText);
-    });
-
-    test("should append a newline if text exists in the output", () => {
-      // Arrange
-      const existingText = "foo";
-      const appendedText = "bar";
-      outputElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendOutput(appendedText, true);
-
-      // Assert
-      expect(outputElement.textContent).toBe(
-        `${existingText}\n${appendedText}`,
-      );
-    });
-
-    test("should not append a newline if text does not exist in the output", () => {
-      // Arrange
-      const existingText = "";
-      const appendedText = "bar";
-      outputElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendOutput(appendedText, true);
-
-      // Assert
-      expect(outputElement.textContent).toBe(`${existingText}${appendedText}`);
-    });
-
-    test("should escape HTML specific characters when appending text to the output element", async () => {
-      // Arrange
-      const existingText = "foo";
-      const appendedText =
-        "TEST<a href='https://nathanwise.tech'>example</a>ING";
-      outputElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendOutput(appendedText);
-
-      // Assert
-      expect(outputElement.textContent).toBe(existingText + appendedText);
-
-      const escapedText =
-        "TEST&lt;a href='https://nathanwise.tech'&gt;example&lt;/a&gt;ING";
-      expect(outputElement.innerHTML).toBe(existingText + escapedText);
-    });
-  });
-  describe("appendRawOutput", () => {
-    test("should append text to the output element", async () => {
-      // Arrange
-      const existingText = "foo";
-      const appendedText = "bar";
-      outputElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendRawOutput(appendedText);
-
-      // Assert
-      expect(outputElement.textContent).toBe(existingText + appendedText);
-    });
-
-    test("should append a newline if text exists in the output", () => {
-      // Arrange
-      const existingText = "foo";
-      const appendedText = "bar";
-      outputElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendRawOutput(appendedText, true);
-
-      // Assert
-      expect(outputElement.textContent).toBe(
-        `${existingText}\n${appendedText}`,
-      );
-    });
-
-    test("should not append a newline if text does not exist in the output", () => {
-      // Arrange
-      const existingText = "";
-      const appendedText = "bar";
-      outputElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendRawOutput(appendedText, true);
-
-      // Assert
-      expect(outputElement.textContent).toBe(`${existingText}${appendedText}`);
-    });
-
-    test("should escape HTML specific characters when appending text to the output element", async () => {
-      // Arrange
-      const existingText = "foo";
-      const appendedText =
-        "TEST<a href='https://nathanwise.tech'>example</a>ING";
-      outputElement.textContent = existingText;
-
-      // Act
-      TerminalUtil.appendRawOutput(appendedText);
-
-      // Assert
-      const onlyText = "TESTexampleING";
-      expect(outputElement.textContent).toBe(existingText + onlyText);
-
-      expect(outputElement.innerHTML).toBe(
-        existingText + appendedText.replace(/'/g, "\""),
-      );
-    });
-  });
-});
-
-// Can't test "cursorToEnd" effectively with JSDom - rely on E2E to test this
-// Can't test "cursorToIndex" effectively with JSDom - rely on E2E to test this

--- a/test/unit/helper/file_tree_mock.ts
+++ b/test/unit/helper/file_tree_mock.ts
@@ -1,7 +1,9 @@
 import { FileTreeNode } from "virtual:file-tree";
 
+/* eslint-disable @typescript-eslint/naming-convention */
 // noinspection JSUnusedGlobalSymbols
 export const fileTree: FileTreeNode[] = [
+  /* eslint-enable @typescript-eslint/naming-convention */
   {
     name: "src",
     path: "",

--- a/test/unit/src/command/scripts/cat.test.ts
+++ b/test/unit/src/command/scripts/cat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../../src/util/terminal_util";
-import cat from "../../../../../src/command/scripts/cat";
+import CAT from "../../../../../src/command/scripts/cat";
 import FileImportUtil from "../../../../../src/util/file_import_util";
 import FileSystemUtil from "../../../../../src/util/file_system_util";
 
@@ -20,7 +20,7 @@ describe("Cat", () => {
       const args: string[] = [];
 
       // Act
-      await cat.run(args);
+      await CAT.run(args);
 
       // Assert
       expect(appendRawOutput).not.toHaveBeenCalled();
@@ -33,7 +33,7 @@ describe("Cat", () => {
       vi.mocked(FileImportUtil.readFile).mockResolvedValueOnce(fileContents);
 
       // Act
-      await cat.run(args);
+      await CAT.run(args);
 
       // Assert
       expect(readFile).toHaveBeenCalledOnce();
@@ -49,7 +49,7 @@ describe("Cat", () => {
       vi.mocked(FileImportUtil.readFile).mockResolvedValueOnce(null);
 
       // Act
-      await cat.run(args);
+      await CAT.run(args);
 
       // Assert
       expect(readFile).toHaveBeenCalledOnce();
@@ -71,7 +71,7 @@ describe("Cat", () => {
         .mockResolvedValueOnce(fileContentsSecond);
 
       // Act
-      await cat.run(args);
+      await CAT.run(args);
 
       // Assert
       expect(readFile).toHaveBeenCalledTimes(2);
@@ -87,7 +87,7 @@ describe("Cat", () => {
       vi.mocked(FileImportUtil.readFile).mockResolvedValue(null);
 
       // Act
-      await cat.run(args);
+      await CAT.run(args);
 
       // Assert
       expect(readFile).toHaveBeenCalledTimes(2);
@@ -109,7 +109,7 @@ describe("Cat", () => {
         .mockResolvedValueOnce(fileContentsFirst);
 
       // Act
-      await cat.run(args);
+      await CAT.run(args);
 
       // Assert
       expect(readFile).toHaveBeenCalledTimes(2);
@@ -127,7 +127,7 @@ describe("Cat", () => {
       vi.mocked(FileImportUtil.readFile).mockResolvedValueOnce(null);
 
       // Act
-      await cat.run(args);
+      await CAT.run(args);
 
       // Assert
       expect(readFile).toHaveBeenCalledOnce();
@@ -146,7 +146,7 @@ describe("Cat", () => {
       vi.mocked(FileImportUtil.readFile).mockResolvedValueOnce(fileContents);
 
       // Act
-      await cat.run(args);
+      await CAT.run(args);
 
       // Assert
       expect(readFile).toHaveBeenCalledOnce();

--- a/test/unit/src/command/scripts/cat.test.ts
+++ b/test/unit/src/command/scripts/cat.test.ts
@@ -5,16 +5,16 @@ import FileImportUtil from "../../../../../src/util/file_import_util";
 import FileSystemUtil from "../../../../../src/util/file_system_util";
 
 describe("Cat", () => {
+  // Spy
+  const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
+  const readFile = vi.spyOn(FileImportUtil, "readFile");
+  const resolvePath = vi.spyOn(FileSystemUtil, "resolvePath");
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+  vi.mock("../../../../../src/util/file_import_util");
+
   describe("run", async () => {
-    // Spy
-    const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
-    const readFile = vi.spyOn(FileImportUtil, "readFile");
-    const resolvePath = vi.spyOn(FileSystemUtil, "resolvePath");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
-    vi.mock("../../../../../src/util/file_import_util");
-
     test("should output nothing when no args are passed", async () => {
       // Arrange
       const args: string[] = [];

--- a/test/unit/src/command/scripts/cd.test.ts
+++ b/test/unit/src/command/scripts/cd.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import cd, {
+import CD, {
   _resetWorkingDirectories,
 } from "../../../../../src/command/scripts/cd";
 import FileSystemUtil from "../../../../../src/util/file_system_util";
@@ -32,7 +32,7 @@ describe("Cd", () => {
         const directoryPath = "/src/main";
 
         // Act
-        await cd.run([directoryPath]);
+        await CD.run([directoryPath]);
 
         // Assert
         expect(setCurrentWorkingDirectory).toHaveBeenCalledExactlyOnceWith(
@@ -47,7 +47,7 @@ describe("Cd", () => {
         FileSystemUtil.setHomeDirectory(homeDirectory);
 
         // Act
-        await cd.run([]);
+        await CD.run([]);
 
         // Assert
         expect(setCurrentWorkingDirectory).toHaveBeenCalledExactlyOnceWith(
@@ -59,12 +59,12 @@ describe("Cd", () => {
       test("'-' as the argument when a previous working directory exists, changes directory to the previous working directory", async () => {
         // Arrange
         const previousWorkingDirectory = "/src/main";
-        await cd.run([previousWorkingDirectory]);
+        await CD.run([previousWorkingDirectory]);
         const currentWorkingDirectory = "/test";
-        await cd.run([currentWorkingDirectory]);
+        await CD.run([currentWorkingDirectory]);
 
         // Act
-        await cd.run(["-"]);
+        await CD.run(["-"]);
 
         // Assert
         expect(setCurrentWorkingDirectory).toHaveBeenCalledTimes(3);
@@ -97,11 +97,11 @@ describe("Cd", () => {
         ];
 
         for (const directoryPath of directoryPaths) {
-          await cd.run([directoryPath]);
+          await CD.run([directoryPath]);
         }
 
         // Act
-        await cd.run(["-"]);
+        await CD.run(["-"]);
 
         // Assert
         expect(setCurrentWorkingDirectory).toHaveBeenCalledTimes(
@@ -130,7 +130,7 @@ describe("Cd", () => {
     describe("Error messages", () => {
       test("more than one argument outputs an error message", async () => {
         // Arrange & Act
-        await cd.run(["/src", "/src"]);
+        await CD.run(["/src", "/src"]);
 
         // Assert
         expect(setCurrentWorkingDirectory).not.toHaveBeenCalled();
@@ -141,7 +141,7 @@ describe("Cd", () => {
 
       test("'-' as the argument when a previous working directory does not exist outputs an error message", async () => {
         // Arrange & Act
-        await cd.run(["-"]);
+        await CD.run(["-"]);
 
         // Assert
         expect(setCurrentWorkingDirectory).not.toHaveBeenCalled();
@@ -155,7 +155,7 @@ describe("Cd", () => {
         const directoryPath = "/src/index.ts";
 
         // Act
-        await cd.run([directoryPath]);
+        await CD.run([directoryPath]);
 
         // Assert
         expect(setCurrentWorkingDirectory).not.toHaveBeenCalled();
@@ -169,7 +169,7 @@ describe("Cd", () => {
         const directoryPath = "/fake/path";
 
         // Act
-        await cd.run([directoryPath]);
+        await CD.run([directoryPath]);
 
         // Assert
         expect(setCurrentWorkingDirectory).not.toHaveBeenCalled();
@@ -183,7 +183,7 @@ describe("Cd", () => {
         const directoryPath = "~test";
 
         // Act
-        await cd.run([directoryPath]);
+        await CD.run([directoryPath]);
 
         // Assert
         expect(setCurrentWorkingDirectory).not.toHaveBeenCalled();

--- a/test/unit/src/command/scripts/cd.test.ts
+++ b/test/unit/src/command/scripts/cd.test.ts
@@ -6,6 +6,16 @@ import FileSystemUtil from "../../../../../src/util/file_system_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
 describe("Cd", () => {
+  // Spy
+  const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
+  const setCurrentWorkingDirectory = vi.spyOn(
+    FileSystemUtil,
+    "setCurrentWorkingDirectory",
+  );
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+
   beforeEach(() => {
     FileSystemUtil.setHomeDirectory("/home/nathanwise");
     FileSystemUtil.setCurrentWorkingDirectory("~");
@@ -16,16 +26,6 @@ describe("Cd", () => {
   });
 
   describe("run", () => {
-    // Spy
-    const setCurrentWorkingDirectory = vi.spyOn(
-      FileSystemUtil,
-      "setCurrentWorkingDirectory",
-    );
-    const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
-
     describe("Successfully changes directory", () => {
       test("an existing directory path argument changes directory to that path", async () => {
         // Arrange

--- a/test/unit/src/command/scripts/clear.test.ts
+++ b/test/unit/src/command/scripts/clear.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../../src/util/terminal_util";
-import clear from "../../../../../src/command/scripts/clear";
+import CLEAR from "../../../../../src/command/scripts/clear";
 
 describe("Clear", () => {
   describe("run", () => {
@@ -15,7 +15,7 @@ describe("Clear", () => {
       const args = ["foo", "bar"];
 
       // Act
-      await clear.run(args);
+      await CLEAR.run(args);
 
       // Assert
       expect(setOutput).toHaveBeenCalledWith("");

--- a/test/unit/src/command/scripts/clear.test.ts
+++ b/test/unit/src/command/scripts/clear.test.ts
@@ -3,13 +3,13 @@ import TerminalUtil from "../../../../../src/util/terminal_util";
 import CLEAR from "../../../../../src/command/scripts/clear";
 
 describe("Clear", () => {
+  // Spy
+  const setOutput = vi.spyOn(TerminalUtil, "setOutput");
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+
   describe("run", () => {
-    // Spy
-    const setOutput = vi.spyOn(TerminalUtil, "setOutput");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
-
     test("should clear the terminal", async () => {
       // Arrange
       const args = ["foo", "bar"];

--- a/test/unit/src/command/scripts/echo.test.ts
+++ b/test/unit/src/command/scripts/echo.test.ts
@@ -3,13 +3,13 @@ import ECHO from "../../../../../src/command/scripts/echo";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
 describe("Echo", () => {
+  // Spy
+  const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+
   describe("run", async () => {
-    // Spy
-    const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
-
     test("should join and append all args", async () => {
       // Arrange
       const args = ["foo", "bar"];

--- a/test/unit/src/command/scripts/echo.test.ts
+++ b/test/unit/src/command/scripts/echo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import echo from "../../../../../src/command/scripts/echo";
+import ECHO from "../../../../../src/command/scripts/echo";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
 describe("Echo", () => {
@@ -15,7 +15,7 @@ describe("Echo", () => {
       const args = ["foo", "bar"];
 
       // Act
-      await echo.run(args);
+      await ECHO.run(args);
 
       // Assert
       expect(appendOutput).toHaveBeenCalledWith("\nfoo bar");
@@ -26,7 +26,7 @@ describe("Echo", () => {
       const args: string[] = [];
 
       // Act
-      await echo.run(args);
+      await ECHO.run(args);
 
       // Assert
       expect(appendOutput).toHaveBeenCalledWith("\n");
@@ -37,7 +37,7 @@ describe("Echo", () => {
       const args = ["foo", "bar", "-a", "baz", "-gaz"];
 
       // Act
-      await echo.run(args);
+      await ECHO.run(args);
 
       // Assert
       expect(appendOutput).toHaveBeenCalledWith("\nfoo bar");

--- a/test/unit/src/command/scripts/ls.test.ts
+++ b/test/unit/src/command/scripts/ls.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import FileSystemUtil from "../../../../../src/util/file_system_util";
-import ls from "../../../../../src/command/scripts/ls";
+import LS from "../../../../../src/command/scripts/ls";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 import ColourUtil from "../../../../../src/util/colour_util";
 
@@ -38,7 +38,7 @@ describe("Ls", () => {
         const args: string[] = [];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith("\nfoo");
@@ -50,7 +50,7 @@ describe("Ls", () => {
         const args: string[] = ["/src/main"];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith("\nfoo");
@@ -62,7 +62,7 @@ describe("Ls", () => {
         const args: string[] = ["/test"];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         expect(appendRawOutput).not.toHaveBeenCalled();
@@ -74,7 +74,7 @@ describe("Ls", () => {
         const args: string[] = ["/src/main/.full"];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith(
@@ -88,7 +88,7 @@ describe("Ls", () => {
         const args: string[] = ["/src/main/.empty"];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         expect(appendRawOutput).not.toHaveBeenCalled();
@@ -100,7 +100,7 @@ describe("Ls", () => {
         const args: string[] = ["/src/index.ts"];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith(
@@ -114,7 +114,7 @@ describe("Ls", () => {
         const args: string[] = ["/src/main/.testing"];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith(
@@ -137,7 +137,7 @@ describe("Ls", () => {
       ].forEach(({ type, args, expected }) => {
         test(`Given ${type}, outputs an error`, async () => {
           // Act
-          await ls.run(args);
+          await LS.run(args);
 
           // Assert
           expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith(
@@ -201,7 +201,7 @@ describe("Ls", () => {
       ].forEach(({ type, args, expected }) => {
         test(`Given multiple arguments (${type}), outputs everything in a structured way`, async () => {
           // Act
-          await ls.run(args);
+          await LS.run(args);
 
           // Assert
           expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith(expected);
@@ -220,7 +220,7 @@ describe("Ls", () => {
         ];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         // foo/bazzing.gaz  foo/daz  .full/aFile  index.ts  .testing
@@ -241,7 +241,7 @@ describe("Ls", () => {
         ];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         const expected =
@@ -276,7 +276,7 @@ describe("Ls", () => {
           args.push(arg);
 
           // Act
-          await ls.run(args);
+          await LS.run(args);
 
           // Assert
           const expected =
@@ -304,7 +304,7 @@ describe("Ls", () => {
           ];
 
           // Act
-          await ls.run(args);
+          await LS.run(args);
 
           // Assert
           const expected =
@@ -335,7 +335,7 @@ describe("Ls", () => {
           "/src/main/.testing",
         ];
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         const expected =
@@ -368,7 +368,7 @@ describe("Ls", () => {
           ];
 
           // Act
-          await ls.run(args);
+          await LS.run(args);
 
           // Assert
           const expected =
@@ -399,7 +399,7 @@ describe("Ls", () => {
           ];
 
           // Act
-          await ls.run(args);
+          await LS.run(args);
 
           // Assert
           const expected =
@@ -435,7 +435,7 @@ describe("Ls", () => {
           ];
 
           // Act
-          await ls.run(args);
+          await LS.run(args);
 
           // Assert
           const expected =
@@ -525,7 +525,7 @@ describe("Ls", () => {
           args.push(...flags);
 
           // Act
-          await ls.run(args);
+          await LS.run(args);
 
           // Assert
           expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith(expected);
@@ -597,7 +597,7 @@ describe("Ls", () => {
           ];
 
           // Act
-          await ls.run(args);
+          await LS.run(args);
 
           // Assert
           expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith(expected);
@@ -620,7 +620,7 @@ describe("Ls", () => {
             ];
 
             // Act
-            await ls.run(args);
+            await LS.run(args);
 
             // Assert
             const expected = `ls: invalid --block-size argument '${blockSize}'`;
@@ -645,7 +645,7 @@ describe("Ls", () => {
         ];
 
         // Act
-        await ls.run(args);
+        await LS.run(args);
 
         // Assert
         const expected =

--- a/test/unit/src/command/scripts/ls.test.ts
+++ b/test/unit/src/command/scripts/ls.test.ts
@@ -5,9 +5,19 @@ import TerminalUtil from "../../../../../src/util/terminal_util";
 import ColourUtil from "../../../../../src/util/colour_util";
 
 describe("Ls", () => {
-  beforeEach(() => {
-    FileSystemUtil.setHomeDirectory("/src/main");
-    FileSystemUtil.setCurrentWorkingDirectory("~");
+  // Spy
+  const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
+  const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+  vi.mock("../../../../../src/util/colour_util");
+
+  // Mocked
+  vi.mocked(ColourUtil.getFileSystemEntryStyle).mockReturnValue({
+    foreground: null,
+    background: null,
+    fontWeight: null,
   });
 
   vi.mocked(ColourUtil.getFileSystemEntry).mockImplementation(
@@ -16,22 +26,12 @@ describe("Ls", () => {
     },
   );
 
+  beforeEach(() => {
+    FileSystemUtil.setHomeDirectory("/src/main");
+    FileSystemUtil.setCurrentWorkingDirectory("~");
+  });
+
   describe("run", () => {
-    // Spy
-    const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
-    const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
-    vi.mock("../../../../../src/util/colour_util");
-
-    // Mocked
-    vi.mocked(ColourUtil.getFileSystemEntryStyle).mockReturnValue({
-      foreground: null,
-      background: null,
-      fontWeight: null,
-    });
-
     describe("No flags", () => {
       test("Given no arguments, outputs the contents of the current working directory", async () => {
         // Arrange

--- a/test/unit/src/command/scripts/pwd.test.ts
+++ b/test/unit/src/command/scripts/pwd.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 import FileSystemUtil from "../../../../../src/util/file_system_util";
-import pwd from "../../../../../src/command/scripts/pwd";
+import PWD from "../../../../../src/command/scripts/pwd";
 
 describe("Pwd", () => {
   describe("run", () => {
@@ -17,7 +17,7 @@ describe("Pwd", () => {
       FileSystemUtil.setCurrentWorkingDirectory(currentWorkingDirectory);
 
       // Act
-      await pwd.run([]);
+      await PWD.run([]);
 
       // Assert
       expect(appendOutput).toHaveBeenCalledExactlyOnceWith(
@@ -31,7 +31,7 @@ describe("Pwd", () => {
       FileSystemUtil.setCurrentWorkingDirectory("~/Desktop");
 
       // Act
-      await pwd.run([]);
+      await PWD.run([]);
 
       // Assert
       expect(appendOutput).toHaveBeenCalledExactlyOnceWith(
@@ -45,12 +45,12 @@ describe("Pwd", () => {
       FileSystemUtil.setCurrentWorkingDirectory(firstCurrentWorkingDirectory);
 
       // Act
-      await pwd.run([]);
+      await PWD.run([]);
 
       const secondCurrentWorkingDirectory = "/usr/local/etc";
       FileSystemUtil.setCurrentWorkingDirectory(secondCurrentWorkingDirectory);
 
-      await pwd.run([]);
+      await PWD.run([]);
 
       // Assert
       expect(appendOutput).toHaveBeenCalledTimes(2);

--- a/test/unit/src/command/scripts/pwd.test.ts
+++ b/test/unit/src/command/scripts/pwd.test.ts
@@ -4,13 +4,13 @@ import FileSystemUtil from "../../../../../src/util/file_system_util";
 import PWD from "../../../../../src/command/scripts/pwd";
 
 describe("Pwd", () => {
+  // Spy
+  const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+
   describe("run", () => {
-    // Spy
-    const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
-
     test("should output the current working directory", async () => {
       // Arrange
       const currentWorkingDirectory = "/home/nathanwise/Desktop";

--- a/test/unit/src/command/scripts/tree.test.ts
+++ b/test/unit/src/command/scripts/tree.test.ts
@@ -5,31 +5,29 @@ import TerminalUtil from "../../../../../src/util/terminal_util.ts";
 import ColourUtil from "../../../../../src/util/colour_util.ts";
 
 describe("Tree", () => {
+  // Spy
+  const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
+  const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+  vi.mock("../../../../../src/util/colour_util");
+
+  vi.mocked(ColourUtil.getFileSystemEntry).mockImplementation(
+    (node, useShortName) => {
+      if (useShortName) {
+        return node.name;
+      }
+
+      return node.path === "" ? `/${node.name}` : `/${node.path}/${node.name}`;
+    },
+  );
+
   beforeEach(() => {
     FileSystemUtil.setCurrentWorkingDirectory("/src/main");
   });
 
   describe("run", () => {
-    // Spy
-    const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
-    const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
-    vi.mock("../../../../../src/util/colour_util");
-
-    vi.mocked(ColourUtil.getFileSystemEntry).mockImplementation(
-      (node, useShortName) => {
-        if (useShortName) {
-          return node.name;
-        }
-
-        return node.path === ""
-          ? `/${node.name}`
-          : `/${node.path}/${node.name}`;
-      },
-    );
-
     describe("No flags", () => {
       test("given no path, should output a tree for the current working directory", async () => {
         // Arrange

--- a/test/unit/src/command/scripts/tree.test.ts
+++ b/test/unit/src/command/scripts/tree.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import tree from "../../../../../src/command/scripts/tree.ts";
+import TREE from "../../../../../src/command/scripts/tree.ts";
 import FileSystemUtil from "../../../../../src/util/file_system_util.ts";
 import TerminalUtil from "../../../../../src/util/terminal_util.ts";
 import ColourUtil from "../../../../../src/util/colour_util.ts";
@@ -36,7 +36,7 @@ describe("Tree", () => {
         const args: string[] = [];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -56,7 +56,7 @@ describe("Tree", () => {
         const args: string[] = ["foo/daz"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -72,7 +72,7 @@ describe("Tree", () => {
         const args: string[] = ["/some/fake/path"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -88,7 +88,7 @@ describe("Tree", () => {
         const args: string[] = ["./foo"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -107,7 +107,7 @@ describe("Tree", () => {
         const args: string[] = ["../../test"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected = "\n/test\n" + "\n" + "0 directories, 0 files";
@@ -120,7 +120,7 @@ describe("Tree", () => {
         const args: string[] = [".full"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -138,7 +138,7 @@ describe("Tree", () => {
         const args: string[] = ["../.."];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -210,7 +210,7 @@ describe("Tree", () => {
       ].forEach(({ type, args, expected }) => {
         test(type, async () => {
           // Act
-          await tree.run(args);
+          await TREE.run(args);
 
           // Assert
           expect(appendOutput).not.toHaveBeenCalled();
@@ -225,7 +225,7 @@ describe("Tree", () => {
         const args = ["../..", "foo/daz", "/some/fake/path", "-a"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -258,7 +258,7 @@ describe("Tree", () => {
         const args = ["../..", "foo/daz", "/some/fake/path", "-d"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -281,7 +281,7 @@ describe("Tree", () => {
         const args = ["../..", "foo/daz", "/some/fake/path", "-ad"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -310,7 +310,7 @@ describe("Tree", () => {
         const args = ["../..", "foo/daz", "/some/fake/path", "--prune"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -335,7 +335,7 @@ describe("Tree", () => {
         const args = ["../..", "foo/daz", "/some/fake/path", "--prune", "-a"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -365,7 +365,7 @@ describe("Tree", () => {
         const args = ["../..", "foo/daz", "/some/fake/path", "-f"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -392,7 +392,7 @@ describe("Tree", () => {
         const args = ["../..", "foo/daz", "/some/fake/path", "-fa"];
 
         // Act
-        await tree.run(args);
+        await TREE.run(args);
 
         // Assert
         const expected =
@@ -490,7 +490,7 @@ describe("Tree", () => {
           ];
 
           // Act
-          await tree.run(args);
+          await TREE.run(args);
 
           // Assert
           expect(appendOutput).not.toHaveBeenCalled();
@@ -504,7 +504,7 @@ describe("Tree", () => {
           const args = ["../..", "foo/daz", "/some/fake/path", "-L", value];
 
           // Act
-          await tree.run(args);
+          await TREE.run(args);
 
           // Assert
           const expected = "\ntree: Invalid level, must be greater than 0.";

--- a/test/unit/src/util/autocomplete_util.test.ts
+++ b/test/unit/src/util/autocomplete_util.test.ts
@@ -7,14 +7,15 @@ import { USER_PROMPT } from "../../../../src/constant/prompt";
 import { Suggestion } from "../../../../src/command/command_script";
 
 describe("AutocompleteUtil", () => {
+  // Spy
+  const appendInput = vi.spyOn(TerminalUtil, "appendInput");
+  const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
+
+  // Mock
+  vi.mock("../../../../src/util/terminal_util");
+  vi.mock("../../../../src/util/meta_import_util");
+
   describe("autocomplete", () => {
-    // Spy
-    const appendInput = vi.spyOn(TerminalUtil, "appendInput");
-    const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-    // Mock
-    vi.mock("../../../../src/util/terminal_util");
-
     describe("Input Insert", () => {
       [
         {
@@ -104,9 +105,6 @@ describe("AutocompleteUtil", () => {
   });
 
   describe("getCommandSuggestions", () => {
-    // Mock
-    vi.mock("../../../../src/util/meta_import_util");
-
     // Other
     beforeEach(async () => {
       await unmock("../../../src/util/meta_import_util", [

--- a/test/unit/src/util/autocomplete_util.test.ts
+++ b/test/unit/src/util/autocomplete_util.test.ts
@@ -3,7 +3,7 @@ import MetaImportUtil from "../../../../src/util/meta_import_util";
 import AutocompleteUtil from "../../../../src/util/autocomplete_util";
 import { unmock } from "../../helper/unmock";
 import TerminalUtil from "../../../../src/util/terminal_util";
-import { userPrompt } from "../../../../src/constant/prompt";
+import { USER_PROMPT } from "../../../../src/constant/prompt";
 import { Suggestion } from "../../../../src/command/command_script";
 
 describe("AutocompleteUtil", () => {
@@ -94,7 +94,7 @@ describe("AutocompleteUtil", () => {
             expect(appendOutput).not.toHaveBeenCalled();
           } else {
             expect(appendOutput).toHaveBeenCalledWith(
-              `${userPrompt}${userInput}\n${expectedAppendText}`,
+              `${USER_PROMPT}${userInput}\n${expectedAppendText}`,
               true,
             );
           }

--- a/test/unit/src/util/colour_util.test.ts
+++ b/test/unit/src/util/colour_util.test.ts
@@ -9,30 +9,30 @@ import {
   RED,
 } from "../../../../src/constant/colour";
 
-describe("ColourUtil", () => {
-  /**
-   * Creates a minimal node with modifications to the fields that matter for `getFileSystemEntryStyle`
-   */
-  function createNode(
-    name: string,
-    isDirectory: boolean,
-    permissions: number[],
-    path?: string,
-  ): FileTreeNode {
-    return {
-      blocks: 0,
-      name: name,
-      path: path === undefined ? "" : path,
-      isDirectory: isDirectory,
-      children: [],
-      lastModifiedTime: new Date(),
-      size: 0,
-      permissions: permissions,
-      owner: "",
-      group: "",
-    };
-  }
+/**
+ * Creates a minimal node with modifications to the fields that matter for `getFileSystemEntryStyle`
+ */
+function createNode(
+  name: string,
+  isDirectory: boolean,
+  permissions: number[],
+  path?: string,
+): FileTreeNode {
+  return {
+    blocks: 0,
+    name: name,
+    path: path === undefined ? "" : path,
+    isDirectory: isDirectory,
+    children: [],
+    lastModifiedTime: new Date(),
+    size: 0,
+    permissions: permissions,
+    owner: "",
+    group: "",
+  };
+}
 
+describe("ColourUtil", () => {
   describe("getFileSystemEntry", () => {
     [
       {

--- a/test/unit/src/util/command_history_util.test.ts
+++ b/test/unit/src/util/command_history_util.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import CommandHistoryUtil from "../../../../src/util/command_history_util";
 
-beforeEach(() => {
-  CommandHistoryUtil.resetHistory();
-  CommandHistoryUtil.resetHistoryIndex();
-});
-
 describe("CommandHistoryUtil", () => {
+  beforeEach(() => {
+    CommandHistoryUtil.resetHistory();
+    CommandHistoryUtil.resetHistoryIndex();
+  });
+
   describe("resetHistory", () => {
     test("resets the history when nothing has been changed", () => {
       // Arrange & Act

--- a/test/unit/src/util/command_history_util.test.ts
+++ b/test/unit/src/util/command_history_util.test.ts
@@ -3,14 +3,14 @@ import CommandHistoryUtil from "../../../../src/util/command_history_util";
 
 describe("CommandHistoryUtil", () => {
   beforeEach(() => {
-    CommandHistoryUtil.resetHistory();
+    CommandHistoryUtil._resetHistory();
     CommandHistoryUtil.resetHistoryIndex();
   });
 
   describe("resetHistory", () => {
     test("resets the history when nothing has been changed", () => {
       // Arrange & Act
-      CommandHistoryUtil.resetHistory();
+      CommandHistoryUtil._resetHistory();
 
       // Assert
       const history = CommandHistoryUtil.getHistory();
@@ -24,7 +24,7 @@ describe("CommandHistoryUtil", () => {
       CommandHistoryUtil.addToHistory("userinput");
 
       // Act
-      CommandHistoryUtil.resetHistory();
+      CommandHistoryUtil._resetHistory();
 
       // Assert
       const history = CommandHistoryUtil.getHistory();
@@ -38,10 +38,10 @@ describe("CommandHistoryUtil", () => {
       CommandHistoryUtil.addToHistory("userinput");
 
       // Act
-      CommandHistoryUtil.resetHistory();
+      CommandHistoryUtil._resetHistory();
 
       // Assert
-      const historyIndex = CommandHistoryUtil.getHistoryIndex();
+      const historyIndex = CommandHistoryUtil._getHistoryIndex();
       expect(historyIndex).toStrictEqual(0);
     });
   });
@@ -52,7 +52,7 @@ describe("CommandHistoryUtil", () => {
       CommandHistoryUtil.resetHistoryIndex();
 
       // Assert
-      const historyIndex = CommandHistoryUtil.getHistoryIndex();
+      const historyIndex = CommandHistoryUtil._getHistoryIndex();
       expect(historyIndex).toEqual(0);
     });
 
@@ -68,7 +68,7 @@ describe("CommandHistoryUtil", () => {
       CommandHistoryUtil.resetHistoryIndex();
 
       // Assert
-      const historyIndex = CommandHistoryUtil.getHistoryIndex();
+      const historyIndex = CommandHistoryUtil._getHistoryIndex();
       expect(historyIndex).toEqual(0);
     });
   });
@@ -85,7 +85,7 @@ describe("CommandHistoryUtil", () => {
 
       // Assert
       expect(wasSuccessful).toEqual(true);
-      const historyIndex = CommandHistoryUtil.getHistoryIndex();
+      const historyIndex = CommandHistoryUtil._getHistoryIndex();
       expect(historyIndex).toBeDefined();
       expect(historyIndex).toEqual(1);
     });
@@ -105,7 +105,7 @@ describe("CommandHistoryUtil", () => {
 
       // Assert
       expect(wasSuccessful).toEqual(false);
-      const historyIndex = CommandHistoryUtil.getHistoryIndex();
+      const historyIndex = CommandHistoryUtil._getHistoryIndex();
       expect(historyIndex).toBeDefined();
       expect(historyIndex).toEqual(2);
     });
@@ -117,7 +117,7 @@ describe("CommandHistoryUtil", () => {
 
       // Assert
       expect(wasSuccessful).toEqual(false);
-      const historyIndex = CommandHistoryUtil.getHistoryIndex();
+      const historyIndex = CommandHistoryUtil._getHistoryIndex();
       expect(historyIndex).toBeDefined();
       expect(historyIndex).toEqual(0);
     });
@@ -136,7 +136,7 @@ describe("CommandHistoryUtil", () => {
 
       // Assert
       expect(wasSuccessful).toEqual(true);
-      const historyIndex = CommandHistoryUtil.getHistoryIndex();
+      const historyIndex = CommandHistoryUtil._getHistoryIndex();
       expect(historyIndex).toBeDefined();
       expect(historyIndex).toEqual(0);
     });
@@ -152,7 +152,7 @@ describe("CommandHistoryUtil", () => {
 
       // Assert
       expect(wasSuccessful).toEqual(false);
-      const historyIndex = CommandHistoryUtil.getHistoryIndex();
+      const historyIndex = CommandHistoryUtil._getHistoryIndex();
       expect(historyIndex).toBeDefined();
       expect(historyIndex).toEqual(0);
     });
@@ -164,7 +164,7 @@ describe("CommandHistoryUtil", () => {
 
       // Assert
       expect(wasSuccessful).toEqual(false);
-      const historyIndex = CommandHistoryUtil.getHistoryIndex();
+      const historyIndex = CommandHistoryUtil._getHistoryIndex();
       expect(historyIndex).toBeDefined();
       expect(historyIndex).toEqual(0);
     });

--- a/test/unit/src/util/command_util.test.ts
+++ b/test/unit/src/util/command_util.test.ts
@@ -12,16 +12,15 @@ describe("CommandUtil", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
 
+  // Mock
+  vi.mock("../../../../src/util/terminal_util");
+  vi.mock("../../../../src/util/meta_import_util");
+
+  beforeEach(async () => {
+    await unmock("../../../src/util/meta_import_util", ["default", "getKey"]);
+  });
+
   describe("executeCommand", () => {
-    // Mock
-    vi.mock("../../../../src/util/terminal_util");
-    vi.mock("../../../../src/util/meta_import_util");
-
-    // Other
-    beforeEach(async () => {
-      await unmock("../../../src/util/meta_import_util", ["default", "getKey"]);
-    });
-
     test("runs a command when it is found", async () => {
       // Arrange
       const mockCommandFile: CommandScript = { run: vi.fn() };
@@ -132,10 +131,6 @@ describe("CommandUtil", () => {
   });
 
   describe("getCommandScripts", () => {
-    // Mock
-    vi.mock("../../../../src/util/meta_import_util");
-
-    // Other
     beforeEach(async () => {
       await unmock("../../../src/util/meta_import_util", ["default", "getKey"]);
     });

--- a/test/unit/src/util/command_util.test.ts
+++ b/test/unit/src/util/command_util.test.ts
@@ -5,7 +5,7 @@ import TokenisedCommand from "../../../../src/dto/tokenised_command";
 import TerminalUtil from "../../../../src/util/terminal_util";
 import { unmock } from "../../helper/unmock";
 import MetaImportUtil from "../../../../src/util/meta_import_util";
-import { userPrompt } from "../../../../src/constant/prompt";
+import { USER_PROMPT } from "../../../../src/constant/prompt";
 import { Options } from "getopts";
 
 describe("CommandUtil", () => {
@@ -55,7 +55,7 @@ describe("CommandUtil", () => {
 
     test("outputs nothing when a command is not found with no name", async () => {
       // Arrange
-      vi.mocked(TerminalUtil.getPrompt).mockReturnValue(userPrompt);
+      vi.mocked(TerminalUtil.getPrompt).mockReturnValue(USER_PROMPT);
       vi.mocked(MetaImportUtil.getCommandScripts).mockReturnValue({});
 
       const command = "";
@@ -65,7 +65,7 @@ describe("CommandUtil", () => {
 
       // Assert
       expect(appendOutput).toHaveBeenCalledOnce();
-      expect(appendOutput).toHaveBeenCalledWith(`${userPrompt}`, true);
+      expect(appendOutput).toHaveBeenCalledWith(`${USER_PROMPT}`, true);
     });
   });
 

--- a/test/unit/src/util/file_system_util.test.ts
+++ b/test/unit/src/util/file_system_util.test.ts
@@ -3,6 +3,9 @@ import FileSystemUtil from "../../../../src/util/file_system_util";
 import { FileTreeNode } from "virtual:file-tree";
 
 describe("FileSystemUtil", () => {
+  // Mocks
+  vi.mock("../../../../src/util/terminal_util");
+
   describe("joinPaths", () => {
     [
       {
@@ -118,9 +121,6 @@ describe("FileSystemUtil", () => {
   });
 
   describe("resolvePathParts", () => {
-    // Mocks
-    vi.mock("../../../../src/util/terminal_util");
-
     interface TestCase {
       type: string;
       path: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,13 @@
 /// <reference types="vitest/config" />
 import { defineConfig, PluginOption } from "vite";
 import autoprefixer from "autoprefixer";
-import FileTree from "./src/plugins/vite_plugin_file_tree";
+import fileTree from "./src/plugins/vite_plugin_file_tree";
 import { visualizer } from "rollup-plugin-visualizer";
 
 export default defineConfig(({ mode }) => {
   return {
     plugins: [
-      FileTree("src/content", "home"),
+      fileTree("src/content", "home"),
       visualizer({ brotliSize: true, gzipSize: true }) as PluginOption,
     ],
     css: {


### PR DESCRIPTION
# Features
- E2E helper methods `runCommand`, `assertExactTextInTerminal`, and `assertOutputInTerminal` 

# Other
- ESLint naming rules for vars, methods, classes, etc.
  - Updated naming across the codebase to match these
- Moved mocks/spies to the top of test files
- Ensured all test files are encompassed in `describe` methods
- Marked all test-only methods with...
  - `_` prefixes in the function name
  - `@internal` in the function JSDoc
- Made EntryNode in `ls` extend FileTreeNode
- Rearranged functions in command scripts 