### PR TITLE
fix: cd - not working properly after a single cd

### DIFF
--- a/src/command/scripts/cd.ts
+++ b/src/command/scripts/cd.ts
@@ -5,10 +5,6 @@ import CommandUtil from "../../util/command_util.ts";
 
 let workingDirectories: string[] = [];
 
-// TODO: Add test for:
-//  1. cd into <DIR>
-//  2. cd -
-//  3. Should CD successfully and not output an error!
 const CD: CommandScript = {
   async run(args: string[]): Promise<void> {
     const parsedOptions = CommandUtil.parseArgs("cd", args, {});
@@ -78,34 +74,26 @@ function changeDirectory(path: string) {
 
   const formattedPath = FileSystemUtil.formatPath(resolvedPathParts);
 
+  updateCurrentWorkingDirectory();
+
   FileSystemUtil.setCurrentWorkingDirectory(formattedPath);
-  addWorkingDirectory(formattedPath);
 }
 
 /**
- * Adds a working directory to a cache.
+ * Updates the cached current working directory with the current working directory.
  * <p>
  * This is used to determine the Previous Working Directory, see {@link getPreviousWorkingDirectory}.
- *
- * @param directory the working directory to add.
  */
-function addWorkingDirectory(directory: string) {
-  workingDirectories.push(directory);
-
-  if (workingDirectories.length > 2) {
-    workingDirectories.shift();
-  }
+function updateCurrentWorkingDirectory() {
+  const currentWorkingDirectory = FileSystemUtil.getCurrentWorkingDirectory();
+  workingDirectories[0] = FileSystemUtil.formatPath(currentWorkingDirectory);
 }
 
 /**
  * @returns the Previous Working Directory or null if it does not exist.
  */
 function getPreviousWorkingDirectory(): string | null {
-  if (workingDirectories.length !== 2) {
-    return null;
-  }
-
-  return workingDirectories[0];
+  return workingDirectories.length === 0 ? null : workingDirectories[0];
 }
 
 /**

--- a/test/e2e/spec/command/cd.spec.ts
+++ b/test/e2e/spec/command/cd.spec.ts
@@ -79,6 +79,32 @@ test.describe("Cd", () => {
   }) => {
     // Arrange
     const previousWorkingDirectory = "/var/tmp";
+
+    await runCommand(page, `cd ${previousWorkingDirectory}`);
+
+    // Act
+    await runCommand(page, "cd -");
+
+    // Assert
+    const expectedOutputText =
+      `${DEFAULT_INITIAL_PROMPT}` +
+      `\n${DEFAULT_USER_PROMPT}cd ${previousWorkingDirectory}` +
+      `\n${getExpectedPrompt(previousWorkingDirectory)}cd -` +
+      `\n${DEFAULT_CURRENT_WORKING_DIRECTORY}`;
+
+    await assertExactTextInTerminal(
+      page,
+      expectedOutputText,
+      getExpectedPrompt(DEFAULT_CURRENT_WORKING_DIRECTORY),
+    );
+    await checkCurrentWorkingDirectory(page, DEFAULT_CURRENT_WORKING_DIRECTORY);
+  });
+
+  test("should change directory to the previous working directory when two previous working directories exist and '-' is provided as a path", async ({
+    page,
+  }) => {
+    // Arrange
+    const previousWorkingDirectory = "/var/tmp";
     const currentWorkingDirectory = "/home";
 
     await runCommand(page, `cd ${previousWorkingDirectory}`);

--- a/test/unit/src/command/scripts/cd.test.ts
+++ b/test/unit/src/command/scripts/cd.test.ts
@@ -16,8 +16,10 @@ describe("Cd", () => {
   // Mock
   vi.mock("../../../../../src/util/terminal_util");
 
+  const homeDirectory = "/src/main";
+
   beforeEach(() => {
-    FileSystemUtil.setHomeDirectory("/home/nathanwise");
+    FileSystemUtil.setHomeDirectory(homeDirectory);
     FileSystemUtil.setCurrentWorkingDirectory("~");
 
     _resetWorkingDirectories();
@@ -57,6 +59,30 @@ describe("Cd", () => {
       });
 
       test("'-' as the argument when a previous working directory exists, changes directory to the previous working directory", async () => {
+        // Arrange
+        const previousWorkingDirectory = "/src/main/foo";
+        await CD.run([previousWorkingDirectory]);
+
+        // Act
+        await CD.run(["-"]);
+
+        // Assert
+        expect(setCurrentWorkingDirectory).toHaveBeenCalledTimes(2);
+        expect(setCurrentWorkingDirectory).toHaveBeenNthCalledWith(
+          1,
+          previousWorkingDirectory,
+        );
+        expect(setCurrentWorkingDirectory).toHaveBeenNthCalledWith(
+          2,
+          homeDirectory,
+        );
+
+        expect(appendOutput).toHaveBeenCalledExactlyOnceWith(
+          `\n${homeDirectory}`,
+        );
+      });
+
+      test("'-' as the argument when two previous working directories exist, changes directory to the previous working directory", async () => {
         // Arrange
         const previousWorkingDirectory = "/src/main";
         await CD.run([previousWorkingDirectory]);
@@ -124,6 +150,35 @@ describe("Cd", () => {
         expect(appendOutput).toHaveBeenCalledExactlyOnceWith(
           `\n${previousWorkingDirectory}`,
         );
+      });
+
+      test("'-' multiple times swaps between two directories", async () => {
+        // Arrange
+        const newDirectory = "/src/main/foo";
+        await CD.run([newDirectory]);
+
+        // Act
+        await CD.run(["-"]);
+        await CD.run(["-"]);
+
+        // Assert
+        expect(setCurrentWorkingDirectory).toHaveBeenCalledTimes(3);
+        expect(setCurrentWorkingDirectory).toHaveBeenNthCalledWith(
+          1,
+          newDirectory,
+        );
+        expect(setCurrentWorkingDirectory).toHaveBeenNthCalledWith(
+          2,
+          homeDirectory,
+        );
+        expect(setCurrentWorkingDirectory).toHaveBeenNthCalledWith(
+          1,
+          newDirectory,
+        );
+
+        expect(appendOutput).toHaveBeenCalledTimes(2);
+        expect(appendOutput).toHaveBeenNthCalledWith(1, `\n${homeDirectory}`);
+        expect(appendOutput).toHaveBeenNthCalledWith(1, `\n${homeDirectory}`);
       });
     });
 


### PR DESCRIPTION
# Features
- Fix cd '-' only working after the second cd '<dir>'