### PR TITLE
feat: clear terminal hotkey

### DIFF
--- a/src/command/scripts/clear.ts
+++ b/src/command/scripts/clear.ts
@@ -5,7 +5,7 @@ import { HelpInformation } from "./help.ts";
 const CLEAR: CommandScript = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async run(_args: string[]): Promise<void> {
-    TerminalUtil.setOutput("");
+    TerminalUtil.clearTerminal();
   },
 
   help(): HelpInformation | null {

--- a/src/event/keydown.ts
+++ b/src/event/keydown.ts
@@ -6,6 +6,7 @@ import { processEnd } from "./keydown_key/end.ts";
 import { processHome } from "./keydown_key/home.ts";
 import { processA } from "./keydown_key/a.ts";
 import { processE } from "./keydown_key/e.ts";
+import { processL } from "./keydown_key/l.ts";
 
 /**
  * Event listener function for handling key down events in the terminal.
@@ -26,6 +27,8 @@ export async function keydown(event: KeyboardEvent) {
     ["End", processEnd],
     ["Enter", processEnter],
     ["Home", processHome],
+    ["l", processL],
+    ["L", processL],
     ["Tab", processTab],
   ]);
 

--- a/src/event/keydown_key/l.ts
+++ b/src/event/keydown_key/l.ts
@@ -1,0 +1,14 @@
+import TerminalUtil from "../../util/terminal_util.ts";
+
+/**
+ * Processes the 'L' key event. Clears the current terminal content if 'Ctrl' is
+ * also pressed.
+ *
+ * @param event event listener {@link KeyboardEvent}
+ */
+export async function processL(event: KeyboardEvent) {
+  if (event.ctrlKey) {
+    event.preventDefault();
+    TerminalUtil.clearTerminal();
+  }
+}

--- a/src/util/terminal_util.ts
+++ b/src/util/terminal_util.ts
@@ -256,6 +256,13 @@ export default class TerminalUtil {
   }
 
   /**
+   * Clears the current terminal output content.
+   */
+  public static clearTerminal() {
+    TerminalUtil.setOutput("");
+  }
+
+  /**
    * Moves the cursor to the end of the Input element's text.
    *
    * @see cursorToIndex

--- a/test/e2e/spec/clear_terminal.spec.ts
+++ b/test/e2e/spec/clear_terminal.spec.ts
@@ -1,0 +1,64 @@
+import { test } from "../fixture";
+import {
+  COMMAND_NOT_FOUND,
+  DEFAULT_USER_PROMPT,
+  INPUT_SELECTOR,
+} from "../helper/constant/generic";
+import {
+  assertExactTextInTerminal,
+  runCommand,
+} from "../helper/util/terminal_util";
+
+["L", "l"].forEach((key) => {
+  test.describe(`Clear Terminal: ${key}`, async () => {
+    test("should do nothing when L is pressed", async ({ page }) => {
+      // Arrange
+      const defaultInput = "foo, bar ?bazgazbaz asd> // testing";
+
+      // Act
+      await runCommand(page, defaultInput); // Rubbish input first to simulate terminal usage
+
+      await page.locator(INPUT_SELECTOR).press(key);
+
+      // Assert
+      // TODO: confirm this is correct
+      const fullExpected = `${DEFAULT_USER_PROMPT}${defaultInput}\nfoo,${COMMAND_NOT_FOUND}`;
+      await assertExactTextInTerminal(page, fullExpected, undefined, key);
+    });
+
+    test("should remove all existing outputs when Ctrl+L is pressed", async ({
+      page,
+    }) => {
+      // Arrange
+      const defaultInput = "foo, bar ?bazgazbaz asd> // testing";
+
+      // Act
+      await runCommand(page, defaultInput); // Rubbish input first to simulate terminal usage
+
+      await page.keyboard.down("Control");
+      await page.locator(INPUT_SELECTOR).press(key);
+      await page.keyboard.up("Control");
+
+      // Assert
+      await assertExactTextInTerminal(page, "", undefined, "");
+    });
+
+    test("output must not have an extra newline after clearing Ctrl+L is pressed", async ({
+      page,
+    }) => {
+      // Arrange
+      const fakeCommand = "fakecommand";
+
+      // Act
+      await page.keyboard.down("Control");
+      await page.locator(INPUT_SELECTOR).press(key);
+      await page.keyboard.up("Control");
+
+      await runCommand(page, fakeCommand);
+
+      // Assert
+      const fullExpected = `${DEFAULT_USER_PROMPT}${fakeCommand}\n${fakeCommand}${COMMAND_NOT_FOUND}`;
+      await assertExactTextInTerminal(page, fullExpected);
+    });
+  });
+});

--- a/test/integration/src/event/keydown_key/l.test.ts
+++ b/test/integration/src/event/keydown_key/l.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect, vi } from "vitest";
+import { processL } from "../../../../../src/event/keydown_key/l.ts";
+import TerminalUtil from "../../../../../src/util/terminal_util.ts";
+
+describe("L", () => {
+  // Spy
+  const clearTerminal = vi.spyOn(TerminalUtil, "clearTerminal");
+
+  // Mock
+  vi.mock("../../../../../src/util/terminal_util");
+
+  describe("processL", async () => {
+    test("with 'Ctrl' clears the terminal content", async () => {
+      // Arrange
+      const event = new KeyboardEvent("keydown", { ctrlKey: true });
+
+      // Act
+      await processL(event);
+
+      // Assert
+      expect(clearTerminal).toHaveBeenCalledOnce();
+    });
+
+    test("without 'Ctrl' does nothing", async () => {
+      // Arrange
+      const event = new KeyboardEvent("keydown");
+
+      // Act
+      await processL(event);
+
+      // Assert
+      expect(clearTerminal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/integration/src/util/terminal_util.test.ts
+++ b/test/integration/src/util/terminal_util.test.ts
@@ -602,6 +602,19 @@ describe("TerminalUtil", () => {
     });
   });
 
+  describe("clearTerminal", async () => {
+    test("should clear the terminal output", async () => {
+      // Arrange
+      outputElement.textContent = "foo bar baz     as d as d\n\n\ngaz";
+
+      // Act
+      TerminalUtil.clearTerminal();
+
+      // Assert
+      expect(outputElement.textContent).toBe("");
+    });
+  });
+
   // Can't test "cursorToEnd" effectively with JSDom - rely on E2E to test this
   // Can't test "cursorToIndex" effectively with JSDom - rely on E2E to test this
 });

--- a/test/unit/src/command/scripts/clear.test.ts
+++ b/test/unit/src/command/scripts/clear.test.ts
@@ -4,7 +4,7 @@ import CLEAR from "../../../../../src/command/scripts/clear";
 
 describe("Clear", () => {
   // Spy
-  const setOutput = vi.spyOn(TerminalUtil, "setOutput");
+  const clearTerminal = vi.spyOn(TerminalUtil, "clearTerminal");
 
   // Mock
   vi.mock("../../../../../src/util/terminal_util");
@@ -18,7 +18,7 @@ describe("Clear", () => {
       await CLEAR.run(args);
 
       // Assert
-      expect(setOutput).toHaveBeenCalledWith("");
+      expect(clearTerminal).toHaveBeenCalledOnce();
     });
   });
 });


### PR DESCRIPTION
# Features
- `Ctrl+L` hotkey to clear the terminal

# Other
- Migrate `Clear` command logic into `TerminalUtil`