### PR TITLE
Input HTML Missing in Output

### DIFF
--- a/src/util/command_util.ts
+++ b/src/util/command_util.ts
@@ -5,6 +5,7 @@ import { CommandScript } from "../command/command_script.ts";
 import TerminalUtil from "./terminal_util.ts";
 import CommandImportUtil from "./command_import_util.ts";
 import FileSystemUtil from "./file_system_util.ts";
+import { escape } from "lodash-es";
 
 export default class CommandUtil {
   /**
@@ -20,7 +21,7 @@ export default class CommandUtil {
     if (tokenisedCommand.name === "") {
       TerminalUtil.appendRawOutput(prompt, true);
     } else {
-      TerminalUtil.appendRawOutput(prompt + command, true);
+      TerminalUtil.appendRawOutput(prompt + escape(command), true);
       TerminalUtil.setInput("");
 
       const commandScript = this.getCommandScript(tokenisedCommand);

--- a/test/e2e/spec/command_parsing.spec.ts
+++ b/test/e2e/spec/command_parsing.spec.ts
@@ -38,6 +38,19 @@ test("Typing an unknown command and pressing Enter returns that the command was 
   );
 });
 
+test("Typing HTML and pressing Enter returns that the commnad was not found", async ({
+  page,
+}) => {
+  // Arrange
+  const input = "<a href=\"https://www.nathanwise.software\">My site!</a>";
+
+  // Act
+  await runCommand(page, input);
+
+  // Assert
+  await assertOutputInTerminal(page, `${input}\n<a${COMMAND_NOT_FOUND}`);
+});
+
 test("Typing no command and pressing Enter does nothing", async ({ page }) => {
   // Arrange & Act
   await runCommand(page, "");

--- a/test/unit/src/util/command_util.test.ts
+++ b/test/unit/src/util/command_util.test.ts
@@ -71,6 +71,26 @@ describe("CommandUtil", () => {
       expect(appendRawOutput).toHaveBeenCalledOnce();
       expect(appendRawOutput).toHaveBeenCalledWith(`${prompt}`, true);
     });
+
+    test("outputs escaped content when HTML content is provided", async () => {
+      // Arrange
+      const prompt = "C:\\home\\nathanwise>";
+      vi.mocked(TerminalUtil.getRawPrompt).mockReturnValue(prompt);
+      vi.mocked(CommandImportUtil.getCommandScripts).mockReturnValue({});
+
+      const command = "echo foo<a href='https://nathanwise.software'>bar</a>";
+
+      // Act
+      await CommandUtil.executeCommand(command);
+
+      // Assert
+      const escapedCommand =
+        "echo foo&lt;a href=&#39;https://nathanwise.software&#39;&gt;bar&lt;/a&gt;";
+      expect(appendRawOutput).toHaveBeenCalledExactlyOnceWith(
+        prompt + escapedCommand,
+        true,
+      );
+    });
   });
 
   describe("tokenise", () => {


### PR DESCRIPTION
# Other
- Fix user inputted HTML (e.g. `<a>asdasd</a>`) disappearing when `Return` is pressed