### PR TITLE
fix: open virtual keyboard on mobile when clicking anywhere

### DIFF
--- a/src/event/click.ts
+++ b/src/event/click.ts
@@ -1,4 +1,5 @@
 import TerminalUtil from "../util/terminal_util.ts";
+import Bowser from "bowser";
 
 /**
  * Event listener function for handling click events in the terminal.
@@ -6,29 +7,41 @@ import TerminalUtil from "../util/terminal_util.ts";
  * @param event event listener {@link MouseEvent}
  */
 export function click(event: MouseEvent) {
-  // Deferring so that selected text can update properly
-  setTimeout(() => {
-    const input = TerminalUtil.getInputElement();
+  const input = TerminalUtil.getInputElement();
 
-    // Allow selecting the input element using default browser behaviour
-    // Allow clicking 'A' tags
-    if (
-      input.contains(event.target as Node) ||
-      (event.target as HTMLElement).tagName === "A"
-    ) {
-      return;
-    }
+  // Allow selecting the input element using default browser behaviour
+  // Allow clicking 'A' tags
+  if (
+    input.contains(event.target as Node) ||
+    (event.target as HTMLElement).tagName === "A"
+  ) {
+    return;
+  }
 
-    const selection: Selection | null = globalThis.getSelection();
-
-    // Allow text highlighting
-    if (selection !== null && !selection.isCollapsed) {
-      return;
-    }
-
+  const browser = Bowser.getParser(window.navigator.userAgent);
+  const focusInput = (event: MouseEvent, input: HTMLElement) => {
     event.preventDefault();
-
     input.focus();
     TerminalUtil.cursorToEnd();
-  }, 0);
+  };
+
+  if (browser.isOS("iOS")) {
+    // iOS does not allow focusing an input Element when deferring inside 'setTimeout', so we cannot check if the text
+    // selection exists or not, and we instead just focus the input.
+    //
+    // Text selection does seem to work regardless.
+    focusInput(event, input);
+  } else {
+    // Deferring so that selected text can update properly
+    setTimeout(() => {
+      const selection: Selection | null = globalThis.getSelection();
+
+      // Allow text highlighting
+      if (selection !== null && !selection.isCollapsed) {
+        return;
+      }
+
+      focusInput(event, input);
+    }, 0);
+  }
 }

--- a/test/e2e/spec/accessibility.spec.ts
+++ b/test/e2e/spec/accessibility.spec.ts
@@ -6,6 +6,8 @@ import {
   PROMPT_SELECTOR,
 } from "../helper/constant/generic";
 import { runCommand } from "../helper/util/terminal_util.ts";
+import { isMobileProject } from "../helper/util/playwright_util.ts";
+import { MOBILE_SAFARI } from "../helper/constant/project.ts";
 
 test.describe("homepage", () => {
   test("should not have any automatically detectable accessibility issues", async ({
@@ -44,7 +46,7 @@ test.describe("homepage", () => {
 test.describe("focus", () => {
   test("clicking anywhere on the web page focuses the terminal", async ({
     page,
-  }) => {
+  }, testInfo) => {
     // Arrange
     const viewportSize = page.viewportSize();
     const maxWidth = viewportSize!.width - 1;
@@ -61,7 +63,12 @@ test.describe("focus", () => {
     // Act & Assert
     const input = page.locator(INPUT_SELECTOR);
     for (const corner of corners) {
-      await page.mouse.click(corner.x, corner.y);
+      if (isMobileProject(testInfo)) {
+        await page.touchscreen.tap(corner.x, corner.y);
+      } else {
+        await page.mouse.click(corner.x, corner.y);
+      }
+
       await expect(
         input,
         `Page clicked in the ${corner.type} to have the terminal focussed`,
@@ -85,7 +92,14 @@ test.describe("focus", () => {
     expect(newPage.url()).toBe("https://github.com/WiseNat/TerminalSite/");
   });
 
-  test("selecting text does not focus the terminal", async ({ page }) => {
+  test("selecting text does not focus the terminal", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name === MOBILE_SAFARI,
+      `Skip on ${MOBILE_SAFARI} due to iOS deferred focus constraint`,
+    );
+
     // Arrange
     const input = "cat ~/help.md";
     await runCommand(page, input);
@@ -107,7 +121,12 @@ test.describe("focus", () => {
 
   test("selecting text and clicking the selected text focuses the terminal", async ({
     page,
-  }) => {
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name === MOBILE_SAFARI,
+      `Skip on ${MOBILE_SAFARI} due to iOS deferred focus constraint`,
+    );
+
     // Arrange
     const input = "cat ~/help.md";
     await runCommand(page, input);
@@ -131,7 +150,12 @@ test.describe("focus", () => {
 
   test("selecting text and clicking the terminal focuses the terminal", async ({
     page,
-  }) => {
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name === MOBILE_SAFARI,
+      `Skip on ${MOBILE_SAFARI} due to iOS deferred focus constraint`,
+    );
+
     // Arrange
     const input = "cat ~/help.md";
     await runCommand(page, input);

--- a/test/integration/src/event/click.test.ts
+++ b/test/integration/src/event/click.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, MockInstance, test, vi } from "vitest";
 import TerminalUtil from "../../../../src/util/terminal_util";
 import { click } from "../../../../src/event/click";
+import Bowser, { Parser } from "bowser";
 
 describe("Click Event", () => {
   // Spy
   const cursorToEnd = vi.spyOn(TerminalUtil, "cursorToEnd");
   let focus: MockInstance<(options?: FocusOptions) => void>;
+
+  // Mock
+  vi.mock("bowser");
 
   // Other
   let inputElement: HTMLElement;
@@ -20,6 +24,11 @@ describe("Click Event", () => {
     inputElement = document.getElementById("input")!;
 
     focus = vi.spyOn(inputElement, "focus");
+
+    vi.mocked(Bowser.getParser).mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      isOS: (_name: string) => false,
+    } as Partial<Parser.Parser> as Parser.Parser);
 
     vi.useFakeTimers();
   });
@@ -63,7 +72,7 @@ describe("Click Event", () => {
       expect(focus).not.toHaveBeenCalled();
     });
 
-    test("should do nothing if text is highlighted", () => {
+    test("should do nothing if text is highlighted on non iOS", () => {
       // Arrange
       const event = new MouseEvent("click");
       Object.defineProperty(event, "target", {
@@ -83,6 +92,33 @@ describe("Click Event", () => {
       // Act
       expect(cursorToEnd).not.toHaveBeenCalled();
       expect(focus).not.toHaveBeenCalled();
+    });
+
+    test("should focus the 'input' element if text is highlighted on an iOS device", () => {
+      // Arrange
+      vi.mocked(Bowser.getParser).mockReturnValue({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        isOS: (_name: string) => true,
+      } as Partial<Parser.Parser> as Parser.Parser);
+
+      const event = new MouseEvent("click");
+      Object.defineProperty(event, "target", {
+        value: document.createElement("div"),
+      });
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      vi.spyOn(globalThis, "getSelection").mockReturnValue({
+        isCollapsed: false,
+      });
+
+      // Assert
+      click(event);
+      vi.runAllTimers();
+
+      // Assert
+      expect(cursorToEnd).toHaveBeenCalledOnce();
+      expect(focus).toHaveBeenCalledOnce();
     });
   });
 });


### PR DESCRIPTION
# Other
- Fix tapping not bringing up the virtual keyboard on iOS due to OS limitations with focussing input elements and deferring
