### PR TITLE
Fix vitest issues

### DIFF
--- a/src/plugins/vite_plugin_file_tree.ts
+++ b/src/plugins/vite_plugin_file_tree.ts
@@ -105,11 +105,11 @@ function isIgnoredFile(entry: fs.Dirent): boolean {
  */
 function getLastModifiedTime(path: string): Date {
   try {
-    const date = new Date(
-      execSync(`git log -1 --format=%ci -- "${path}"`, {
-        encoding: "utf-8",
-      }).trim(),
-    );
+    const output = execSync(`git log -1 --format=%ci -- "${path}"`, {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"], // silence stderr
+    });
+    const date = new Date(output.trim());
 
     if (!Number.isNaN(date.getTime())) {
       return date;

--- a/test/integration/src/command/scripts/cat.test.ts
+++ b/test/integration/src/command/scripts/cat.test.ts
@@ -16,7 +16,7 @@ describe("Cat", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/cat.test.ts
+++ b/test/integration/src/command/scripts/cat.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Cat", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/cd.test.ts
+++ b/test/integration/src/command/scripts/cd.test.ts
@@ -16,7 +16,7 @@ describe("Cd", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/cd.test.ts
+++ b/test/integration/src/command/scripts/cd.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Cd", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/clear.test.ts
+++ b/test/integration/src/command/scripts/clear.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Clear", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/clear.test.ts
+++ b/test/integration/src/command/scripts/clear.test.ts
@@ -16,7 +16,7 @@ describe("Clear", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/download.test.ts
+++ b/test/integration/src/command/scripts/download.test.ts
@@ -16,7 +16,7 @@ describe("Download", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/download.test.ts
+++ b/test/integration/src/command/scripts/download.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Download", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/echo.test.ts
+++ b/test/integration/src/command/scripts/echo.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Echo", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/echo.test.ts
+++ b/test/integration/src/command/scripts/echo.test.ts
@@ -16,7 +16,7 @@ describe("Echo", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/fake/corrupt.test.ts
+++ b/test/integration/src/command/scripts/fake/corrupt.test.ts
@@ -14,7 +14,7 @@ describe("Commands that are Corrupted", () => {
       // Act & Assert
       expect(
         async () => await CommandUtil.executeCommand(commandName),
-      ).not.toThrowError();
+      ).not.toThrow();
 
       expect(appendOutput).not.toHaveBeenCalledWith(
         `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/fake/corrupt.test.ts
+++ b/test/integration/src/command/scripts/fake/corrupt.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../../../src/util/terminal_util.ts";
 import CommandUtil from "../../../../../../src/util/command_util.ts";
 
+// Mocks
+vi.mock("../../../../../../src/util/terminal_util");
+
 describe("Commands that are Corrupted", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../../src/util/terminal_util");
 
   ["date", "df", "more", "ps", "sed", "sh"].forEach((commandName) => {
     test("should run with CommandUtil", () => {

--- a/test/integration/src/command/scripts/fake/no_perms.test.ts
+++ b/test/integration/src/command/scripts/fake/no_perms.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../../../src/util/terminal_util.ts";
 import CommandUtil from "../../../../../../src/util/command_util.ts";
 
+// Mocks
+vi.mock("../../../../../../src/util/terminal_util");
+
 describe("Commands that the User has no Permissions to Execute", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../../src/util/terminal_util");
 
   [
     "chgrp",

--- a/test/integration/src/command/scripts/fake/no_perms.test.ts
+++ b/test/integration/src/command/scripts/fake/no_perms.test.ts
@@ -35,7 +35,7 @@ describe("Commands that the User has no Permissions to Execute", () => {
       // Act & Assert
       expect(
         async () => await CommandUtil.executeCommand(commandName),
-      ).not.toThrowError();
+      ).not.toThrow();
 
       expect(appendOutput).not.toHaveBeenCalledWith(
         `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/fake/nothing.test.ts
+++ b/test/integration/src/command/scripts/fake/nothing.test.ts
@@ -14,7 +14,7 @@ describe("Commands that Output Nothing", () => {
       // Act & Assert
       expect(
         async () => await CommandUtil.executeCommand(commandName),
-      ).not.toThrowError();
+      ).not.toThrow();
 
       expect(appendOutput).not.toHaveBeenCalledWith(
         `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/fake/nothing.test.ts
+++ b/test/integration/src/command/scripts/fake/nothing.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../../../src/util/terminal_util.ts";
 import CommandUtil from "../../../../../../src/util/command_util.ts";
 
+// Mocks
+vi.mock("../../../../../../src/util/terminal_util");
+
 describe("Commands that Output Nothing", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../../src/util/terminal_util");
 
   ["true", "false"].forEach((commandName) => {
     test("should run with CommandUtil", () => {

--- a/test/integration/src/command/scripts/help.test.ts
+++ b/test/integration/src/command/scripts/help.test.ts
@@ -17,7 +17,7 @@ describe("Help", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/help.test.ts
+++ b/test/integration/src/command/scripts/help.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/formatter_util");
+
 describe("Help", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/formatter_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/hostname.test.ts
+++ b/test/integration/src/command/scripts/hostname.test.ts
@@ -16,7 +16,7 @@ describe("Hostname", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/hostname.test.ts
+++ b/test/integration/src/command/scripts/hostname.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Hostname", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/ls.test.ts
+++ b/test/integration/src/command/scripts/ls.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/formatter_util");
+
 describe("Ls", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/formatter_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/ls.test.ts
+++ b/test/integration/src/command/scripts/ls.test.ts
@@ -17,7 +17,7 @@ describe("Ls", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/neofetch.test.ts
+++ b/test/integration/src/command/scripts/neofetch.test.ts
@@ -3,14 +3,15 @@ import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 import { mockExtractVisibleText } from "../../../../unit/helper/mocks.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/html_util");
+
 describe("Neofetch", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
 
-  // Mock
   mockExtractVisibleText();
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/html_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/neofetch.test.ts
+++ b/test/integration/src/command/scripts/neofetch.test.ts
@@ -20,7 +20,7 @@ describe("Neofetch", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/pwd.test.ts
+++ b/test/integration/src/command/scripts/pwd.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Pwd", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/pwd.test.ts
+++ b/test/integration/src/command/scripts/pwd.test.ts
@@ -16,7 +16,7 @@ describe("Pwd", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/reboot.test.ts
+++ b/test/integration/src/command/scripts/reboot.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Reboot", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/reboot.test.ts
+++ b/test/integration/src/command/scripts/reboot.test.ts
@@ -4,6 +4,7 @@ import TerminalUtil from "../../../../../src/util/terminal_util";
 
 // Mocks
 vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/html_util");
 
 describe("Reboot", () => {
   // Spy

--- a/test/integration/src/command/scripts/reboot.test.ts
+++ b/test/integration/src/command/scripts/reboot.test.ts
@@ -16,7 +16,7 @@ describe("Reboot", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/terminal.test.ts
+++ b/test/integration/src/command/scripts/terminal.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Terminal", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/terminal.test.ts
+++ b/test/integration/src/command/scripts/terminal.test.ts
@@ -16,7 +16,7 @@ describe("Terminal", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/tree.test.ts
+++ b/test/integration/src/command/scripts/tree.test.ts
@@ -16,7 +16,7 @@ describe("Tree", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/tree.test.ts
+++ b/test/integration/src/command/scripts/tree.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Tree", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/command/scripts/uname.test.ts
+++ b/test/integration/src/command/scripts/uname.test.ts
@@ -16,7 +16,7 @@ describe("Uname", () => {
     // Act & Assert
     expect(
       async () => await CommandUtil.executeCommand(commandName),
-    ).not.toThrowError();
+    ).not.toThrow();
 
     expect(appendOutput).not.toHaveBeenCalledWith(
       `\n${commandName}: command not found`,

--- a/test/integration/src/command/scripts/uname.test.ts
+++ b/test/integration/src/command/scripts/uname.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import CommandUtil from "../../../../../src/util/command_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Uname", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   test("should run with CommandUtil", () => {
     // Arrange

--- a/test/integration/src/event/click.test.ts
+++ b/test/integration/src/event/click.test.ts
@@ -3,13 +3,13 @@ import TerminalUtil from "../../../../src/util/terminal_util";
 import { click } from "../../../../src/event/click";
 import Bowser, { Parser } from "bowser";
 
+// Mocks
+vi.mock("bowser");
+
 describe("Click Event", () => {
   // Spy
   const cursorToEnd = vi.spyOn(TerminalUtil, "cursorToEnd");
   let focus: MockInstance<(options?: FocusOptions) => void>;
-
-  // Mock
-  vi.mock("bowser");
 
   // Other
   let inputElement: HTMLElement;

--- a/test/integration/src/event/keydown.test.ts
+++ b/test/integration/src/event/keydown.test.ts
@@ -9,6 +9,16 @@ import * as homeModule from "../../../../src/event/keydown_key/home";
 import * as aModule from "../../../../src/event/keydown_key/a";
 import * as eModule from "../../../../src/event/keydown_key/e";
 
+// Mocks
+vi.mock("../../../../src/event/keydown_key/a");
+vi.mock("../../../../src/event/keydown_key/arrow_down");
+vi.mock("../../../../src/event/keydown_key/arrow_up");
+vi.mock("../../../../src/event/keydown_key/e");
+vi.mock("../../../../src/event/keydown_key/end");
+vi.mock("../../../../src/event/keydown_key/enter");
+vi.mock("../../../../src/event/keydown_key/home");
+vi.mock("../../../../src/event/keydown_key/tab");
+
 describe("Keydown Event", () => {
   // Spy
   const processA = vi.spyOn(aModule, "processA");
@@ -19,16 +29,6 @@ describe("Keydown Event", () => {
   const processEnter = vi.spyOn(enterModule, "processEnter");
   const processHome = vi.spyOn(homeModule, "processHome");
   const processTab = vi.spyOn(tabModule, "processTab");
-
-  // Mock
-  vi.mock("../../../../src/event/keydown_key/a");
-  vi.mock("../../../../src/event/keydown_key/arrow_down");
-  vi.mock("../../../../src/event/keydown_key/arrow_up");
-  vi.mock("../../../../src/event/keydown_key/e");
-  vi.mock("../../../../src/event/keydown_key/end");
-  vi.mock("../../../../src/event/keydown_key/enter");
-  vi.mock("../../../../src/event/keydown_key/home");
-  vi.mock("../../../../src/event/keydown_key/tab");
 
   describe("keydown", () => {
     // Other

--- a/test/integration/src/event/keydown_key/a.test.ts
+++ b/test/integration/src/event/keydown_key/a.test.ts
@@ -2,12 +2,12 @@ import { describe, test, expect, vi } from "vitest";
 import { processA } from "../../../../../src/event/keydown_key/a";
 import * as homeModule from "../../../../../src/event/keydown_key/home";
 
+// Mocks
+vi.mock("../../../../../src/event/keydown_key/home");
+
 describe("A", () => {
   // Spy
   const processHome = vi.spyOn(homeModule, "processHome");
-
-  // Mock
-  vi.mock("../../../../../src/event/keydown_key/home");
 
   describe("processA", async () => {
     test("with 'Ctrl' moves the cursor to the start of the user input", async () => {

--- a/test/integration/src/event/keydown_key/arrow_down.test.ts
+++ b/test/integration/src/event/keydown_key/arrow_down.test.ts
@@ -3,14 +3,14 @@ import TerminalUtil from "../../../../../src/util/terminal_util";
 import { processArrowDown } from "../../../../../src/event/keydown_key/arrow_down";
 import CommandHistoryUtil from "../../../../../src/util/command_history_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/command_history_util");
+
 describe("ArrowDown", () => {
   // Spy
   const setHistoricCommand = vi.spyOn(CommandHistoryUtil, "setHistoricCommand");
   const setInput = vi.spyOn(TerminalUtil, "setInput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/command_history_util");
 
   describe("without 'Shift'", () => {
     // Other

--- a/test/integration/src/event/keydown_key/arrow_up.test.ts
+++ b/test/integration/src/event/keydown_key/arrow_up.test.ts
@@ -3,14 +3,14 @@ import TerminalUtil from "../../../../../src/util/terminal_util";
 import { processArrowUp } from "../../../../../src/event/keydown_key/arrow_up";
 import CommandHistoryUtil from "../../../../../src/util/command_history_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/command_history_util");
+
 describe("ArrowUp", () => {
   // Spy
   const setHistoricCommand = vi.spyOn(CommandHistoryUtil, "setHistoricCommand");
   const setInput = vi.spyOn(TerminalUtil, "setInput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/command_history_util");
 
   describe("without 'Shift'", () => {
     // Other

--- a/test/integration/src/event/keydown_key/e.test.ts
+++ b/test/integration/src/event/keydown_key/e.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import * as endModule from "../../../../../src/event/keydown_key/end";
 import { processE } from "../../../../../src/event/keydown_key/e";
 
+// Mocks
+vi.mock("../../../../../src/event/keydown_key/end");
+
 describe("E", () => {
   // Spy
   const processEnd = vi.spyOn(endModule, "processEnd");
-
-  // Mock
-  vi.mock("../../../../../src/event/keydown_key/end");
 
   describe("processE", () => {
     test("with 'Ctrl' moves the cursor to the end of the user input", async () => {

--- a/test/integration/src/event/keydown_key/end.test.ts
+++ b/test/integration/src/event/keydown_key/end.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 import { processEnd } from "../../../../../src/event/keydown_key/end";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("End", () => {
   // Spy
   const cursorToEnd = vi.spyOn(TerminalUtil, "cursorToEnd");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   const event = new KeyboardEvent("keydown");
 

--- a/test/integration/src/event/keydown_key/enter.test.ts
+++ b/test/integration/src/event/keydown_key/enter.test.ts
@@ -4,16 +4,16 @@ import CommandUtil from "../../../../../src/util/command_util";
 import { processEnter } from "../../../../../src/event/keydown_key/enter";
 import CommandHistoryUtil from "../../../../../src/util/command_history_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/command_util");
+
 describe("Enter", () => {
   // Spy
   const executeCommand = vi.spyOn(CommandUtil, "executeCommand");
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
   const addToHistory = vi.spyOn(CommandHistoryUtil, "addToHistory");
   const setHistoricCommand = vi.spyOn(CommandHistoryUtil, "setHistoricCommand");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/command_util");
 
   beforeEach(() => {
     CommandHistoryUtil._resetHistory();

--- a/test/integration/src/event/keydown_key/home.test.ts
+++ b/test/integration/src/event/keydown_key/home.test.ts
@@ -3,13 +3,13 @@ import { processHome } from "../../../../../src/event/keydown_key/home";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 import { ZERO_WIDTH_SPACE } from "../../../../e2e/helper/constant/generic";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Home", () => {
   describe("processHome", () => {
     // Spy
     const cursorToIndex = vi.spyOn(TerminalUtil, "cursorToIndex");
-
-    // Mock
-    vi.mock("../../../../../src/util/terminal_util");
 
     const event = new KeyboardEvent("keydown");
 

--- a/test/integration/src/event/keydown_key/l.test.ts
+++ b/test/integration/src/event/keydown_key/l.test.ts
@@ -2,12 +2,12 @@ import { describe, test, expect, vi } from "vitest";
 import { processL } from "../../../../../src/event/keydown_key/l.ts";
 import TerminalUtil from "../../../../../src/util/terminal_util.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("L", () => {
   // Spy
   const clearTerminal = vi.spyOn(TerminalUtil, "clearTerminal");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   describe("processL", async () => {
     test("with 'Ctrl' clears the terminal content", async () => {

--- a/test/integration/src/event/keydown_key/tab.test.ts
+++ b/test/integration/src/event/keydown_key/tab.test.ts
@@ -6,6 +6,11 @@ import CommandUtil from "../../../../../src/util/command_util";
 import AutocompleteUtil from "../../../../../src/util/autocomplete_util";
 import HtmlUtil from "../../../../../src/util/html_util.ts";
 
+// Mock
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/command_import_util");
+vi.mock("../../../../../src/util/html_util");
+
 describe("Tab", () => {
   // Spy
   const getCommandScript = vi.spyOn(CommandUtil, "getCommandScript");
@@ -18,11 +23,6 @@ describe("Tab", () => {
     "getFileAndDirectorySuggestions",
   );
   const autocomplete = vi.spyOn(AutocompleteUtil, "autocomplete");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/command_import_util");
-  vi.mock("../../../../../src/util/html_util");
 
   const event = new KeyboardEvent("keydown");
 

--- a/test/integration/src/plugin/vite_plugin_file_tree.test.ts
+++ b/test/integration/src/plugin/vite_plugin_file_tree.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import fs from "fs";
 import { walk } from "../../../../src/plugins/vite_plugin_file_tree";
 import { sortBy } from "lodash-es";
 import { FileTreeNode } from "virtual:file-tree";
@@ -35,7 +34,7 @@ describe("VitePluginTree", () => {
 
       // Act
       const tree = walk(testRootDir);
-      fs.rmSync(testRootDir, { recursive: true, force: true });
+      vol.rmSync(testRootDir, { recursive: true, force: true });
 
       // Assert
       expect(deepSortTree(tree)).toMatchInlineSnapshot(`
@@ -140,7 +139,7 @@ describe("VitePluginTree", () => {
 
       // Act
       const tree = walk(testRootDir);
-      fs.rmSync(testRootDir, { recursive: true, force: true });
+      vol.rmSync(testRootDir, { recursive: true, force: true });
 
       // Assert
       expect(deepSortTree(tree)).toMatchInlineSnapshot(`
@@ -179,7 +178,7 @@ describe("VitePluginTree", () => {
 
       // Act
       const tree = walk(testRootDir);
-      fs.rmSync(testRootDir, { recursive: true, force: true });
+      vol.rmSync(testRootDir, { recursive: true, force: true });
 
       // Assert
       expect(deepSortTree(tree)).toMatchInlineSnapshot(`
@@ -220,7 +219,7 @@ describe("VitePluginTree", () => {
 
       // Act
       const tree = walk(testRootDir, "some/home");
-      fs.rmSync(testRootDir, { recursive: true, force: true });
+      vol.rmSync(testRootDir, { recursive: true, force: true });
 
       // Assert
       expect(deepSortTree(tree)).toMatchInlineSnapshot(`
@@ -400,7 +399,7 @@ describe("VitePluginTree", () => {
 
       // Act
       const tree = walk(testRootDir);
-      fs.rmSync(testRootDir, { recursive: true, force: true });
+      vol.rmSync(testRootDir, { recursive: true, force: true });
 
       // Assert
       expect(deepSortTree(tree)).toMatchInlineSnapshot(`

--- a/test/integration/src/util/terminal_util.test.ts
+++ b/test/integration/src/util/terminal_util.test.ts
@@ -8,10 +8,10 @@ let inputElement: HTMLElement;
 let promptElement: HTMLElement;
 let outputElement: HTMLElement;
 
-describe("TerminalUtil", () => {
-  // Mocks
-  vi.mock("../../../../src/util/flavour_util");
+// Mocks
+vi.mock("../../../../src/util/flavour_util");
 
+describe("TerminalUtil", () => {
   beforeEach(() => {
     // Mock terminal elements
     document.body.innerHTML =

--- a/test/unit/src/command/scripts/cat.test.ts
+++ b/test/unit/src/command/scripts/cat.test.ts
@@ -4,15 +4,15 @@ import CAT from "../../../../../src/command/scripts/cat";
 import FileImportUtil from "../../../../../src/util/file_import_util";
 import FileSystemUtil from "../../../../../src/util/file_system_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/file_import_util");
+
 describe("Cat", () => {
   // Spy
   const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
   const readFile = vi.spyOn(FileImportUtil, "readFile");
   const resolvePathParts = vi.spyOn(FileSystemUtil, "resolvePathParts");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/file_import_util");
 
   describe("run", async () => {
     test("should output nothing when no args are passed", async () => {

--- a/test/unit/src/command/scripts/cd.test.ts
+++ b/test/unit/src/command/scripts/cd.test.ts
@@ -5,6 +5,9 @@ import CD, {
 import FileSystemUtil from "../../../../../src/util/file_system_util";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Cd", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
@@ -12,9 +15,6 @@ describe("Cd", () => {
     FileSystemUtil,
     "setCurrentWorkingDirectory",
   );
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   const homeDirectory = "/src/main";
 

--- a/test/unit/src/command/scripts/clear.test.ts
+++ b/test/unit/src/command/scripts/clear.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 import CLEAR from "../../../../../src/command/scripts/clear";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Clear", () => {
   // Spy
   const clearTerminal = vi.spyOn(TerminalUtil, "clearTerminal");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   describe("run", () => {
     test("should clear the terminal", async () => {

--- a/test/unit/src/command/scripts/download.test.ts
+++ b/test/unit/src/command/scripts/download.test.ts
@@ -77,11 +77,8 @@ describe("Download", () => {
 
       vi.stubGlobal(
         "fetch",
-        vi.fn(() => {
-          return new Response("example body data", {
-            status: 200,
-            headers: { "Content-Type": "text/plain" },
-          });
+        vi.fn().mockResolvedValue({
+          ok: true,
         }),
       );
 

--- a/test/unit/src/command/scripts/download.test.ts
+++ b/test/unit/src/command/scripts/download.test.ts
@@ -3,13 +3,13 @@ import TerminalUtil from "../../../../../src/util/terminal_util.ts";
 import DOWNLOAD from "../../../../../src/command/scripts/download.ts";
 import FileImportUtil from "../../../../../src/util/file_import_util.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/file_import_util");
+
 describe("Download", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/file_import_util");
 
   beforeEach(() => {
     vi.unstubAllGlobals();

--- a/test/unit/src/command/scripts/echo.test.ts
+++ b/test/unit/src/command/scripts/echo.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import ECHO from "../../../../../src/command/scripts/echo";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Echo", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   describe("run", async () => {
     test("should join and append all args", async () => {

--- a/test/unit/src/command/scripts/fake/corrupt.test.ts
+++ b/test/unit/src/command/scripts/fake/corrupt.test.ts
@@ -7,12 +7,12 @@ import DATE from "../../../../../../src/command/scripts/fake/date.ts";
 import DF from "../../../../../../src/command/scripts/fake/df.ts";
 import PS from "../../../../../../src/command/scripts/fake/ps.ts";
 
+// Mocks
+vi.mock("../../../../../../src/util/terminal_util");
+
 describe("Commands that Output Nothing", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../../src/util/terminal_util");
 
   [
     { command: "date", commandScript: DATE },

--- a/test/unit/src/command/scripts/fake/no_perms.test.ts
+++ b/test/unit/src/command/scripts/fake/no_perms.test.ts
@@ -21,12 +21,12 @@ import SYNC from "../../../../../../src/command/scripts/fake/sync.ts";
 import UNMOUNT from "../../../../../../src/command/scripts/fake/unmount.ts";
 import SUDO from "../../../../../../src/command/scripts/fake/sudo.ts";
 
+// Mocks
+vi.mock("../../../../../../src/util/terminal_util");
+
 describe("Commands that the User has no Permissions to Execute", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../../src/util/terminal_util");
 
   [
     { command: "chgrp", commandScript: CHGRP },

--- a/test/unit/src/command/scripts/help.test.ts
+++ b/test/unit/src/command/scripts/help.test.ts
@@ -7,16 +7,18 @@ import CommandImportUtil from "../../../../../src/util/command_import_util.ts";
 import { mockExtractVisibleText } from "../../../helper/mocks.ts";
 import CssUtil from "../../../../../src/util/css_util.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/command_import_util");
+vi.mock("../../../../../src/util/html_util");
+vi.mock("../../../../../src/util/css_util");
+
 describe("Help", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
 
   // Mock
   mockExtractVisibleText();
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/command_import_util");
-  vi.mock("../../../../../src/util/html_util");
-  vi.mock("../../../../../src/util/css_util");
 
   describe("run", async () => {
     beforeEach(() => {

--- a/test/unit/src/command/scripts/hostname.test.ts
+++ b/test/unit/src/command/scripts/hostname.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, vi, test } from "vitest";
 import TerminalUtil from "../../../../../src/util/terminal_util.ts";
 import HOSTNAME_COMMAND from "../../../../../src/command/scripts/hostname.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Hostname", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   describe("run", () => {
     test("should output the hostname when no arguments are provided", async () => {

--- a/test/unit/src/command/scripts/ls.test.ts
+++ b/test/unit/src/command/scripts/ls.test.ts
@@ -4,15 +4,15 @@ import LS from "../../../../../src/command/scripts/ls";
 import TerminalUtil from "../../../../../src/util/terminal_util";
 import FormatterUtil from "../../../../../src/util/formatter_util.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/formatter_util");
+vi.mock("../../../../src/util/formatter_util");
+
 describe("Ls", () => {
   // Spy
   const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/formatter_util");
-  vi.mock("../../../../src/util/formatter_util");
 
   // Mocked
   vi.mocked(FormatterUtil.getFileSystemEntryStyle).mockReturnValue({

--- a/test/unit/src/command/scripts/neofetch.test.ts
+++ b/test/unit/src/command/scripts/neofetch.test.ts
@@ -57,22 +57,22 @@ function containsInfoText(text: string) {
   return true;
 }
 
+// Mock
+mockExtractVisibleText();
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/html_util");
+vi.mock("../../../../../src/util/time_util", () => ({
+  default: {
+    loadTime: 0,
+  },
+}));
+vi.mock("../../../../../src/util/theme_util");
+vi.mock("../../../../../src/util/flavour_util");
+
 describe("Neofetch", () => {
   // Spy
   const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
   vi.spyOn(navigator, "hardwareConcurrency", "get").mockReturnValue(8);
-
-  // Mock
-  mockExtractVisibleText();
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/html_util");
-  vi.mock("../../../../../src/util/time_util", () => ({
-    default: {
-      loadTime: 0,
-    },
-  }));
-  vi.mock("../../../../../src/util/theme_util");
-  vi.mock("../../../../../src/util/flavour_util");
 
   beforeEach(() => {
     vi.unstubAllGlobals();

--- a/test/unit/src/command/scripts/pwd.test.ts
+++ b/test/unit/src/command/scripts/pwd.test.ts
@@ -3,12 +3,12 @@ import TerminalUtil from "../../../../../src/util/terminal_util";
 import FileSystemUtil from "../../../../../src/util/file_system_util";
 import PWD from "../../../../../src/command/scripts/pwd";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Pwd", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   describe("run", () => {
     test("should output the current working directory", async () => {

--- a/test/unit/src/command/scripts/reboot.test.ts
+++ b/test/unit/src/command/scripts/reboot.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import REBOOT from "../../../../../src/command/scripts/reboot.ts";
 import HtmlUtil from "../../../../../src/util/html_util.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/html_util");
+
 describe("Reboot", () => {
   // Spy
   const refreshPage = vi.spyOn(HtmlUtil, "refreshPage");
-
-  // Mock
-  vi.mock("../../../../../src/util/html_util");
 
   describe("run", () => {
     test("should restart the webpage", async () => {

--- a/test/unit/src/command/scripts/terminal.test.ts
+++ b/test/unit/src/command/scripts/terminal.test.ts
@@ -5,6 +5,11 @@ import FlavourUtil from "../../../../../src/util/flavour_util.ts";
 import { Flavour } from "../../../../../src/flavour/flavour.ts";
 import ThemeUtil from "../../../../../src/util/theme_util.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/flavour_util");
+vi.mock("../../../../../src/util/theme_util");
+
 describe("Terminal", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
@@ -13,11 +18,6 @@ describe("Terminal", () => {
     "setCurrentShellFlavour",
   );
   const setTheme = vi.spyOn(ThemeUtil, "setTheme");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/flavour_util");
-  vi.mock("../../../../../src/util/theme_util");
 
   describe("run", async () => {
     describe("No flags", () => {

--- a/test/unit/src/command/scripts/tree.test.ts
+++ b/test/unit/src/command/scripts/tree.test.ts
@@ -4,14 +4,14 @@ import FileSystemUtil from "../../../../../src/util/file_system_util.ts";
 import TerminalUtil from "../../../../../src/util/terminal_util.ts";
 import FormatterUtil from "../../../../../src/util/formatter_util.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+vi.mock("../../../../../src/util/formatter_util");
+
 describe("Tree", () => {
   // Spy
   const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
-  vi.mock("../../../../../src/util/formatter_util");
 
   vi.mocked(FormatterUtil.getFileSystemEntry).mockImplementation(
     (node, useShortName) => {

--- a/test/unit/src/command/scripts/uname.test.ts
+++ b/test/unit/src/command/scripts/uname.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test, vi } from "vitest";
 import TerminalUtil from "../../../../../src/util/terminal_util.ts";
 import UNAME from "../../../../../src/command/scripts/uname.ts";
 
+// Mocks
+vi.mock("../../../../../src/util/terminal_util");
+
 describe("Hostname", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
-
-  // Mock
-  vi.mock("../../../../../src/util/terminal_util");
 
   // Other
   const kernelName = "Linux";

--- a/test/unit/src/util/autocomplete_util.test.ts
+++ b/test/unit/src/util/autocomplete_util.test.ts
@@ -7,15 +7,15 @@ import { Suggestion } from "../../../../src/command/command_script";
 import { ZERO_WIDTH_SPACE } from "../../helper/constant.ts";
 import FormatterUtil from "../../../../src/util/formatter_util.ts";
 
+// Mocks
+vi.mock("../../../../src/util/terminal_util");
+vi.mock("../../../../src/util/command_import_util");
+vi.mock("../../../../src/util/formatter_util");
+
 describe("AutocompleteUtil", () => {
   // Spy
   const setInput = vi.spyOn(TerminalUtil, "setInput");
   const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
-
-  // Mock
-  vi.mock("../../../../src/util/terminal_util");
-  vi.mock("../../../../src/util/command_import_util");
-  vi.mock("../../../../src/util/formatter_util");
 
   const prompt = "C:\\home\\nathanwise>";
 

--- a/test/unit/src/util/command_history_util.test.ts
+++ b/test/unit/src/util/command_history_util.test.ts
@@ -288,7 +288,7 @@ describe("CommandHistoryUtil", () => {
       // Act & Assert
       expect(() => {
         CommandHistoryUtil.setHistoricCommand(overwrittenValue);
-      }).not.toThrowError();
+      }).not.toThrow();
 
       const historicCommand = CommandHistoryUtil.getHistoricCommand();
       expect(historicCommand).toEqual(overwrittenValue);

--- a/test/unit/src/util/command_util.test.ts
+++ b/test/unit/src/util/command_util.test.ts
@@ -6,14 +6,14 @@ import { unmock } from "../../helper/unmock";
 import CommandImportUtil from "../../../../src/util/command_import_util.ts";
 import { Options } from "getopts";
 
+// Mocks
+vi.mock("../../../../src/util/terminal_util");
+vi.mock("../../../../src/util/command_import_util");
+
 describe("CommandUtil", () => {
   // Spy
   const appendOutput = vi.spyOn(TerminalUtil, "appendOutput");
   const appendRawOutput = vi.spyOn(TerminalUtil, "appendRawOutput");
-
-  // Mock
-  vi.mock("../../../../src/util/terminal_util");
-  vi.mock("../../../../src/util/command_import_util");
 
   beforeEach(async () => {
     await unmock("../../../src/util/command_import_util", [

--- a/test/unit/src/util/file_system_util.test.ts
+++ b/test/unit/src/util/file_system_util.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, test, vi } from "vitest";
 import FileSystemUtil from "../../../../src/util/file_system_util";
 import { FileTreeNode } from "virtual:file-tree";
 
-describe("FileSystemUtil", () => {
-  // Mocks
-  vi.mock("../../../../src/util/terminal_util");
+// Mocks
+vi.mock("../../../../src/util/terminal_util");
 
+describe("FileSystemUtil", () => {
   describe("joinPaths", () => {
     [
       {

--- a/test/unit/src/util/flavour_util.test.ts
+++ b/test/unit/src/util/flavour_util.test.ts
@@ -5,6 +5,10 @@ import FlavourUtil from "../../../../src/util/flavour_util.ts";
 import TerminalUtil from "../../../../src/util/terminal_util.ts";
 import UNIX from "../../../../src/flavour/implementation/Unix.ts";
 
+// Mocks
+vi.mock("../../../../src/util/flavour_import_util");
+vi.mock("../../../../src/util/terminal_util");
+
 describe("FlavourUtil", () => {
   // Spy
   const setPromptPath = vi.spyOn(TerminalUtil, "setPromptPath");
@@ -14,10 +18,6 @@ describe("FlavourUtil", () => {
     FlavourUtil,
     "setCurrentShellFlavour",
   );
-
-  // Mock
-  vi.mock("../../../../src/util/flavour_import_util");
-  vi.mock("../../../../src/util/terminal_util");
 
   beforeEach(() => {
     FlavourUtil._resetCurrentShellFlavour();

--- a/test/unit/src/util/formatter_util.test.ts
+++ b/test/unit/src/util/formatter_util.test.ts
@@ -35,12 +35,12 @@ function createNode(
   };
 }
 
-describe("FormatterUtil", () => {
-  // Mock
-  vi.mock("../../../../src/util/terminal_util");
-  vi.mock("../../../../src/util/css_util");
-  vi.mock("../../../../src/util/html_util");
+// Mocks
+vi.mock("../../../../src/util/terminal_util");
+vi.mock("../../../../src/util/css_util");
+vi.mock("../../../../src/util/html_util");
 
+describe("FormatterUtil", () => {
   mockExtractVisibleText();
 
   describe("getFileSystemEntry", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,11 @@ import { resolve } from "node:path";
 
 export default defineConfig({
   test: {
+    reporters: ["minimal"],
+
+    // Only enable when debugging as this massively slows down tests - https://vitest.dev/config/detectasyncleaks.html#detectasyncleaks
+    // detectAsyncLeaks: true,
+
     projects: [
       defineConfig({
         test: {


### PR DESCRIPTION
# Other
- Fix Vitest Hoist Warnings
- Replace deprecated `toThrowError` with `toThrow`
- Fix irrelevant console logs when running tests
- Fix async leak in `download.test.ts`
- Change Vitest reporter to be less obnoxious
