### PR TITLE
fix: only append "" from TRAILING_WHITESPACE tokens when necessary

### DIFF
--- a/src/command/scripts/help.ts
+++ b/src/command/scripts/help.ts
@@ -23,10 +23,6 @@ export interface HelpInformation {
 
 const HELP: CommandScript = {
   async run(args: string[]): Promise<void> {
-    if (args.at(-1) === "") {
-      args.pop();
-    }
-
     const parsedOptions = CommandUtil.parseArgs("help", args, {
       boolean: ["d", "s"],
     });

--- a/src/event/keydown_key/tab.ts
+++ b/src/event/keydown_key/tab.ts
@@ -35,7 +35,9 @@ export async function processTab(event: KeyboardEvent) {
 
   const lexer = new Lexer(beforeCaret);
   const simpleCommand: SimpleCommand = Parser.parse(lexer);
-  const executionCommand: ExecutionCommand = Expander.expand(simpleCommand);
+  const executionCommand: ExecutionCommand = Expander.expand(simpleCommand, {
+    returnTrailingWhitespace: true,
+  });
 
   let suggestions: Suggestion[];
 

--- a/src/shell/expander/expander.ts
+++ b/src/shell/expander/expander.ts
@@ -7,14 +7,22 @@ import {
   TokenType,
 } from "../common.ts";
 
+export type ExpanderConfig = {
+  returnTrailingWhitespace?: boolean;
+};
+
 export default class Expander {
   /**
    * Converts a single {@link CommandNode} into an {@link ExecutionCommandNode}.
    *
    * @param commandNode
+   * @param expanderConfig
    * @throws Error if any {@link CommandNode} other than a {@link SimpleCommand} is provided
    */
-  public static expand(commandNode: CommandNode): ExecutionCommandNode {
+  public static expand(
+    commandNode: CommandNode,
+    expanderConfig?: ExpanderConfig,
+  ): ExecutionCommandNode {
     if (commandNode.type !== "SimpleCommand") {
       throw new Error(`Unsupported Command Type '${commandNode.type}'`);
     }
@@ -23,7 +31,7 @@ export default class Expander {
     // TODO: resolve variable substitutions
 
     // Browsing the tree is not required as we currently can only ever have a single node
-    return this.expandSimpleCommand(commandNode);
+    return this.expandSimpleCommand(commandNode, expanderConfig);
   }
 
   /**
@@ -36,10 +44,12 @@ export default class Expander {
    * This will also 'consume' available quotes when converting tokens into the `name` and `args`.
    *
    * @param simpleCommand the {@link SimpleCommand} to expand & convert
+   * @param expanderConfig
    * @private
    */
   private static expandSimpleCommand(
     simpleCommand: SimpleCommand,
+    expanderConfig?: ExpanderConfig,
   ): ExecutionCommand {
     let name: string = "";
     const args: string[] = [];
@@ -49,7 +59,10 @@ export default class Expander {
     for (let i = 0; i < tokens.length; i++) {
       const token = tokens[i];
 
-      const value: string | undefined | null = this.getTokenValue(token);
+      const value: string | undefined | null = this.getTokenValue(
+        token,
+        expanderConfig,
+      );
       if (value === undefined || value === null) {
         continue;
       }
@@ -67,12 +80,16 @@ export default class Expander {
   /**
    * Converts {@link Token} values into expander friendly values.
    * @param token
+   * @param expanderConfig
    * @private
    */
-  private static getTokenValue(token: Token): string | null | undefined {
+  private static getTokenValue(
+    token: Token,
+    expanderConfig?: ExpanderConfig,
+  ): string | null | undefined {
     switch (token.type) {
       case TokenType.TRAILING_WHITESPACE:
-        return "";
+        return expanderConfig?.returnTrailingWhitespace ? "" : null;
       case TokenType.EOF:
         return null;
       case TokenType.WORD:

--- a/test/unit/src/shell/expander/expander.test.ts
+++ b/test/unit/src/shell/expander/expander.test.ts
@@ -100,7 +100,7 @@ describe("Expander", () => {
       expect(command.args).toStrictEqual([]);
     });
 
-    test("returns an execution command with an empty string as the last element in args when given a simple command with trailing whitespace", () => {
+    test("returns an execution command with an empty string as the last element in args when given a simple command with trailing whitespace and returnTrailingWhitespace=true in the expander config", () => {
       // Arrange
       const tokens: Token[] = [
         {
@@ -115,18 +115,6 @@ describe("Expander", () => {
           type: TokenType.WORD,
           parts: [{ type: TokenPartType.LITERAL, value: "bar" }],
         },
-        {
-          type: TokenType.WORD,
-          parts: [{ type: TokenPartType.LITERAL, value: "baz" }],
-        },
-        {
-          type: TokenType.WORD,
-          parts: [{ type: TokenPartType.LITERAL, value: "gaz" }],
-        },
-        {
-          type: TokenType.WORD,
-          parts: [{ type: TokenPartType.LITERAL, value: "daz" }],
-        },
         { type: TokenType.TRAILING_WHITESPACE, parts: null },
         { type: TokenType.EOF, parts: null },
       ];
@@ -136,18 +124,59 @@ describe("Expander", () => {
       };
 
       // Act
-      const command = Expander.expand(simpleCommand);
+      const command = Expander.expand(simpleCommand, {
+        returnTrailingWhitespace: true,
+      });
 
       // Assert
       expect(command.name).toBe("echo");
-      expect(command.args).toStrictEqual([
-        "foo",
-        "bar",
-        "baz",
-        "gaz",
-        "daz",
-        "",
-      ]);
+      expect(command.args).toStrictEqual(["foo", "bar", ""]);
+    });
+
+    [
+      {
+        type: "returnTrailingWhitespace=false in the expander config",
+        config: { returnTrailingWhitespace: false },
+      },
+      {
+        type: "an empty expander config",
+        config: {},
+      },
+      {
+        type: "an undefined expander confiog",
+        config: undefined,
+      },
+    ].forEach(({ type, config }) => {
+      test(`returns an execution command without an empty string as the last element in args when given a simple command with trailing whitespace and ${type}`, () => {
+        // Arrange
+        const tokens: Token[] = [
+          {
+            type: TokenType.WORD,
+            parts: [{ type: TokenPartType.LITERAL, value: "echo" }],
+          },
+          {
+            type: TokenType.WORD,
+            parts: [{ type: TokenPartType.LITERAL, value: "foo" }],
+          },
+          {
+            type: TokenType.WORD,
+            parts: [{ type: TokenPartType.LITERAL, value: "bar" }],
+          },
+          { type: TokenType.TRAILING_WHITESPACE, parts: null },
+          { type: TokenType.EOF, parts: null },
+        ];
+        const simpleCommand: SimpleCommand = {
+          type: "SimpleCommand",
+          words: tokens,
+        };
+
+        // Act
+        const command = Expander.expand(simpleCommand, config);
+
+        // Assert
+        expect(command.name).toBe("echo");
+        expect(command.args).toStrictEqual(["foo", "bar"]);
+      });
     });
 
     test("returns an execution command with no quotation marks when given a simple command with quotation mark tokens", () => {


### PR DESCRIPTION
# Other
- Add a configuration to `Expander` for appending `TRAILING_WHITESPACE` tokens in `args`
- Change `tab.ts` to use new `returnTrailingWhitespace` configuration